### PR TITLE
Run all sanity tests

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -19,13 +19,13 @@ jobs:
         with:
           path: ansible_collections/community/digitalocean
 
-      - name: Set up Python 3.6
+      - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: 3.8
 
       - name: Install ansible-base (${{ matrix.ansible }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
 
       - name: Run sanity tests
-        run: ansible-test sanity --docker -v --color --python 3.6
+        run: ansible-test sanity --docker -v --color


### PR DESCRIPTION
##### SUMMARY
Currently some sanity tests are not run at all, because the Python version is fixed to 3.6.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
CI
