### PR TITLE
Fix CI by marking false-positives with no_log=False

### DIFF
--- a/plugins/modules/digital_ocean.py
+++ b/plugins/modules/digital_ocean.py
@@ -433,7 +433,7 @@ def main():
             size_id=dict(),
             image_id=dict(),
             region_id=dict(),
-            ssh_key_ids=dict(type='list'),
+            ssh_key_ids=dict(type='list', no_log=False),
             virtio=dict(type='bool', default=True),
             private_networking=dict(type='bool', default=False),
             backups_enabled=dict(type='bool', default=False),

--- a/plugins/modules/digital_ocean_droplet.py
+++ b/plugins/modules/digital_ocean_droplet.py
@@ -321,7 +321,7 @@ def main():
             size=dict(aliases=['size_id']),
             image=dict(aliases=['image_id']),
             region=dict(aliases=['region_id']),
-            ssh_keys=dict(type='list'),
+            ssh_keys=dict(type='list', no_log=False),
             private_networking=dict(type='bool', default=False),
             vpc_uuid=dict(type='str'),
             backups=dict(type='bool', default=False),


### PR DESCRIPTION
##### SUMMARY
Currently CI is broken, since the sanity tests fail (https://github.com/ansible-collections/overview/issues/45#issuecomment-797617217).

Fortunately these are only false-positives in this collection. This PR marks them as such.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
digital_ocean
digital_ocean_droplet
