### PR TITLE
Fixes rel inventory script --host option: don't throw ValueError on invalid droplet ID, return JSON conformant with specification.

### DIFF
--- a/changelogs/fragments/44-fixes-inv-script-host-option.yaml
+++ b/changelogs/fragments/44-fixes-inv-script-host-option.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Fail cleaner on invalid ``HOST`` arg to inventory script ``--host`` option (https://github.com/ansible-collections/community.digitalocean/pull/44).
+  - Return JSON consistent with spec from inventory script with ``--host`` (https://github.com/ansible-collections/community.digitalocean/pull/44).

--- a/changelogs/fragments/44-fixes-inv-script-host-option.yaml
+++ b/changelogs/fragments/44-fixes-inv-script-host-option.yaml
@@ -1,3 +1,3 @@
 bugfixes:
   - digital_ocean inventory script - fail cleaner on invalid ``HOST`` argument to ``--host`` option (https://github.com/ansible-collections/community.digitalocean/pull/44).
-  - Return JSON consistent with spec from inventory script with ``--host`` (https://github.com/ansible-collections/community.digitalocean/pull/44).
+  - digital_ocean inventory script - return JSON consistent with specification with ``--host`` (https://github.com/ansible-collections/community.digitalocean/pull/44).

--- a/changelogs/fragments/44-fixes-inv-script-host-option.yaml
+++ b/changelogs/fragments/44-fixes-inv-script-host-option.yaml
@@ -1,3 +1,3 @@
 bugfixes:
-  - Fail cleaner on invalid ``HOST`` arg to inventory script ``--host`` option (https://github.com/ansible-collections/community.digitalocean/pull/44).
+  - digital_ocean inventory script - fail cleaner on invalid ``HOST`` argument to ``--host`` option (https://github.com/ansible-collections/community.digitalocean/pull/44).
   - Return JSON consistent with spec from inventory script with ``--host`` (https://github.com/ansible-collections/community.digitalocean/pull/44).

--- a/scripts/inventory/digital_ocean.py
+++ b/scripts/inventory/digital_ocean.py
@@ -345,8 +345,8 @@ class DigitalOceanInventory(object):
         parser = argparse.ArgumentParser(description='Produce an Ansible Inventory file based on DigitalOcean credentials')
 
         parser.add_argument('--list', action='store_true', help='List all active Droplets as Ansible inventory (default: True)')
-        parser.add_argument('--host', action='store',  type=int,
-            help='Get all Ansible inventory variables about the Droplet with the given ID')
+        parser.add_argument('--host', action='store', type=int,
+                            help='Get all Ansible inventory variables about the Droplet with the given ID')
 
         parser.add_argument('--all', action='store_true', help='List all DigitalOcean information as JSON')
         parser.add_argument('--droplets', '-d', action='store_true', help='List Droplets as JSON')

--- a/scripts/inventory/digital_ocean.py
+++ b/scripts/inventory/digital_ocean.py
@@ -87,8 +87,8 @@ optional arguments:
   -h, --help            show this help message and exit
   --list                List all active Droplets as Ansible inventory
                         (default: True)
-  --host HOST           Get all Ansible inventory variables about a specific
-                        Droplet
+  --host HOST           Get all Ansible inventory variables about the Droplet
+                        with the given ID
   --all                 List all DigitalOcean information as JSON
   --droplets, -d        List Droplets as JSON
   --regions             List Regions as JSON
@@ -208,7 +208,7 @@ class DoManager:
 
     def show_droplet(self, droplet_id):
         resp = self.send('droplets/%s' % droplet_id)
-        return resp['droplet']
+        return resp.get('droplet', {})
 
     def all_tags(self):
         resp = self.send('tags')
@@ -345,7 +345,8 @@ class DigitalOceanInventory(object):
         parser = argparse.ArgumentParser(description='Produce an Ansible Inventory file based on DigitalOcean credentials')
 
         parser.add_argument('--list', action='store_true', help='List all active Droplets as Ansible inventory (default: True)')
-        parser.add_argument('--host', action='store', help='Get all Ansible inventory variables about a specific Droplet')
+        parser.add_argument('--host', action='store',  type=int,
+            help='Get all Ansible inventory variables about the Droplet with the given ID')
 
         parser.add_argument('--all', action='store_true', help='List all DigitalOcean information as JSON')
         parser.add_argument('--droplets', '-d', action='store_true', help='List Droplets as JSON')
@@ -481,10 +482,9 @@ class DigitalOceanInventory(object):
 
     def load_droplet_variables_for_host(self):
         """ Generate a JSON response to a --host call """
-        host = int(self.args.host)
-        droplet = self.manager.show_droplet(host)
+        droplet = self.manager.show_droplet(self.args.host)
         info = self.do_namespace(droplet)
-        return {'droplet': info}
+        return info
 
     ###########################################################################
     # Cache Management


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Two minor fixes related to the `--host` option to the inventory script:

1. Currently if a non integer value is passed the script throws this back at you:

```
python ./hosts/digital_ocean.py --host abc
Traceback (most recent call last):
  File "./hosts/digital_ocean.py", line 541, in <module>
    DigitalOceanInventory()
  File "./hosts/digital_ocean.py", line 293, in __init__
    json_data = self.load_droplet_variables_for_host()
  File "./hosts/digital_ocean.py", line 484, in load_droplet_variables_for_host
    host = int(self.args.host)
ValueError: invalid literal for int() with base 10: 'abc'
```
This PR fixes this by declaring that the `--host` arg should be an int in `parseargs`, which makes it a bit clearer what the HOST arg is actually supposed to be:

```
python ./hosts/digital_ocean.py --host abc
usage: digital_ocean.py [-h] [--list] [--host HOST] [--all] [--droplets]
                        [--regions] [--images] [--sizes] [--ssh-keys]
                        [--domains] [--tags] [--pretty]
                        [--cache-path CACHE_PATH]
                        [--cache-max_age CACHE_MAX_AGE] [--force-cache]
                        [--refresh-cache] [--env] [--api-token API_TOKEN]
digital_ocean.py: error: argument --host: invalid int value: 'abc'
```

2. According to the [spec](https://docs.ansible.com/ansible/latest/dev_guide/developing_inventory.html#inventory-script-conventions), with `--host` option, inventory scripts are supposed to return one of two things: an object with vars at the *top level* (currently they are nested like `{ droplet: { ... } }`, PR removes the `droplet` nesting), or an empty object `{}`. Spec doesn't say specifically what should be returned if host does not exist, but in lack of further spec I've presumed it should be `{}`. This PR tweaks the output of `--host` to be consistent with that. It doesn't matter much since the script returns `_meta` and `--host` should not be used by Ansible, but still think given a either/or choice it's best to be consistent with spec.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
scripts/inventory/digital_ocean.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
