### PR TITLE
Implement documented but unimplemented `use_private_network` INI config option.

### DIFF
--- a/changelogs/fragments/45-fix-use_private_network.yaml
+++ b/changelogs/fragments/45-fix-use_private_network.yaml
@@ -1,4 +1,4 @@
 bugfixes:
-  - Implement unimplemented ``use_private_network`` option to digital_ocean.py
+  - digital_ocean inventory script - implement unimplemented ``use_private_network`` option
     inventory script, and register missing ``do_ip_address``, ``do_private_ip_address``
     host vars (https://github.com/ansible-collections/community.digitalocean/pull/45/files).

--- a/changelogs/fragments/45-fix-use_private_network.yaml
+++ b/changelogs/fragments/45-fix-use_private_network.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - Implement unimplemented ``use_private_network`` option to digital_ocean.py
+    inventory script, and register missing ``do_ip_address``, ``do_private_ip_address``
+    host vars (https://github.com/ansible-collections/community.digitalocean/pull/45/files).

--- a/changelogs/fragments/45-fix-use_private_network.yaml
+++ b/changelogs/fragments/45-fix-use_private_network.yaml
@@ -1,4 +1,4 @@
 bugfixes:
   - digital_ocean inventory script - implement unimplemented ``use_private_network`` option
-    inventory script, and register missing ``do_ip_address``, ``do_private_ip_address``
+    and register missing ``do_ip_address``, ``do_private_ip_address``
     host vars (https://github.com/ansible-collections/community.digitalocean/pull/45/files).

--- a/scripts/inventory/digital_ocean.py
+++ b/scripts/inventory/digital_ocean.py
@@ -445,15 +445,19 @@ class DigitalOceanInventory(object):
         for droplet in self.data['droplets']:
             for net in droplet['networks']['v4']:
                 if net['type'] == 'public':
-                    dest = net['ip_address']
-                else:
-                    continue
+                    droplet['ip_address'] = net['ip_address']
+                elif net['type'] == 'private':
+                    droplet['private_ip_address'] = net['ip_address']
 
-            self.inventory['all']['hosts'].append(dest)
+            host_indentifier = droplet['ip_address']
+            if self.use_private_network and droplet['private_ip_address']:
+                host_indentifier = droplet['private_ip_address']
 
-            self.add_host(droplet['id'], dest)
+            self.inventory['all']['hosts'].append(host_indentifier)
 
-            self.add_host(droplet['name'], dest)
+            self.add_host(droplet['id'], host_indentifier)
+
+            self.add_host(droplet['name'], host_indentifier)
 
             # groups that are always present
             for group in ('digital_ocean',
@@ -462,22 +466,22 @@ class DigitalOceanInventory(object):
                           'size_' + droplet['size']['slug'],
                           'distro_' + DigitalOceanInventory.to_safe(droplet['image']['distribution']),
                           'status_' + droplet['status']):
-                self.add_host(group, dest)
+                self.add_host(group, host_indentifier)
 
             # groups that are not always present
             for group in (droplet['image']['slug'],
                           droplet['image']['name']):
                 if group:
                     image = 'image_' + DigitalOceanInventory.to_safe(group)
-                    self.add_host(image, dest)
+                    self.add_host(image, host_indentifier)
 
             if droplet['tags']:
                 for tag in droplet['tags']:
-                    self.add_host(tag, dest)
+                    self.add_host(tag, host_indentifier)
 
             # hostvars
             info = self.do_namespace(droplet)
-            self.inventory['_meta']['hostvars'][dest] = info
+            self.inventory['_meta']['hostvars'][host_indentifier] = info
 
     def load_droplet_variables_for_host(self):
         """ Generate a JSON response to a --host call """


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

`use_private_network` is documented as a inventory script INI config option. This options is present in code but it's not hooked up to anything. This PR hooks it up in a manner consistent with the description of how it should work that exist in code:

> Use the private network IP address instead of the public when available.

In addition, code docs states `do_ip_address` and `do_private_ip_address` variables are registered by the inventory script. However, they weren't. This PR registers these fields as they are used in implementing `use_private_network`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
scripts/inventory/digital_ocean.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
