### PR TITLE
Revert CHANGELOG.rst changes from #41

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,17 +5,6 @@ Community DigitalOcean Release Notes
 .. contents:: Topics
 
 
-v1.1.0
-======
-
-New Plugins
------------
-
-Inventory
-~~~~~~~~~
-
-- digitalocean - DigitalOcean Inventory Plugin
-
 v1.0.0
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -16,10 +16,3 @@ releases:
     - 14-docs-fqcn.yaml
     - 3-sanity-docs-fixes.yaml
     release_date: '2020-08-17'
-  1.1.0:
-    plugins:
-      inventory:
-      - description: DigitalOcean Inventory Plugin
-        name: digitalocean
-        namespace: null
-    release_date: '2021-03-25'


### PR DESCRIPTION
This should make `ansible-changelog release` happier, once version `1.1.0` is ready.