### PR TITLE
load_balancer_info, certificate_info: Fix base URL

### DIFF
--- a/changelogs/fragments/49-fix-lb-and-cert-info.yaml
+++ b/changelogs/fragments/49-fix-lb-and-cert-info.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - digital_ocean_load_balancer_info - Fix retrieving load balancer by ID (https://github.com/ansible-collections/community.digitalocean/issues/35).
+  - digital_ocean_certificate_info - Fix retrieving certificate by ID.

--- a/changelogs/fragments/49-fix-lb-and-cert-info.yaml
+++ b/changelogs/fragments/49-fix-lb-and-cert-info.yaml
@@ -1,3 +1,3 @@
 bugfixes:
-  - digital_ocean_load_balancer_info - Fix retrieving load balancer by ID (https://github.com/ansible-collections/community.digitalocean/issues/35).
-  - digital_ocean_certificate_info - Fix retrieving certificate by ID.
+  - digital_ocean_load_balancer_info - fix retrieving load balancer by ID (https://github.com/ansible-collections/community.digitalocean/issues/35).
+  - digital_ocean_certificate_info - fix retrieving certificate by ID (https://github.com/ansible-collections/community.digitalocean/issues/35).

--- a/plugins/modules/digital_ocean_certificate_info.py
+++ b/plugins/modules/digital_ocean_certificate_info.py
@@ -79,7 +79,7 @@ def core(module):
     certificate_id = module.params.get('certificate_id', None)
     rest = DigitalOceanHelper(module)
 
-    base_url = 'certificates?'
+    base_url = 'certificates'
     if certificate_id is not None:
         response = rest.get("%s/%s" % (base_url, certificate_id))
         status_code = response.status_code
@@ -90,7 +90,7 @@ def core(module):
         resp_json = response.json
         certificate = resp_json['certificate']
     else:
-        certificate = rest.get_paginated_data(base_url=base_url, data_key_name='certificates')
+        certificate = rest.get_paginated_data(base_url=base_url + '?', data_key_name='certificates')
 
     module.exit_json(changed=False, data=certificate)
 

--- a/plugins/modules/digital_ocean_load_balancer_info.py
+++ b/plugins/modules/digital_ocean_load_balancer_info.py
@@ -81,7 +81,7 @@ def core(module):
     load_balancer_id = module.params.get('load_balancer_id', None)
     rest = DigitalOceanHelper(module)
 
-    base_url = 'load_balancers?'
+    base_url = 'load_balancers'
     if load_balancer_id is not None:
         response = rest.get("%s/%s" % (base_url, load_balancer_id))
         status_code = response.status_code
@@ -92,7 +92,7 @@ def core(module):
         resp_json = response.json
         load_balancer = resp_json['load_balancer']
     else:
-        load_balancer = rest.get_paginated_data(base_url=base_url, data_key_name='load_balancers')
+        load_balancer = rest.get_paginated_data(base_url=base_url + '?', data_key_name='load_balancers')
 
     module.exit_json(changed=False, data=load_balancer)
 


### PR DESCRIPTION
##### SUMMARY

Fix for https://github.com/ansible-collections/community.digitalocean/issues/35 The failure reported there happens because the base URL is incorrect. It contains a trailing `?`. When building a URL for retrieving a single load balancer, it creates a malformated URL, e.g. `https://api.digitalocean.com/v2/load_balancers?/e3eb82b5-2766-42f3-a74c-d20a0fbb881c`. The API interprets the ID as a query parameter and returns a list of `load_balancers` rather than the single `load_balancer`. Hence the KeyError.

`digital_ocean_certificate_info` suffers from the same issue.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- load_balancer_info
- digital_ocean_certificate_info

##### ADDITIONAL INFORMATION

Test case:

```paste below
---
- hosts: localhost
  connection: local

  vars:
    do_load_balancer_id: ""
    do_certificate_id: ""
    oauth_token: "{{ lookup('env', 'DO_TOKEN') }}"

  tasks:
  # Fails before fix
  - name: Get information about the load balancer
    community.digitalocean.digital_ocean_load_balancer_info:
      load_balancer_id: "{{ do_load_balancer_id }}"
      oauth_token: "{{ oauth_token }}"

  - name: Get information about all load balancers
    community.digitalocean.digital_ocean_load_balancer_info:
      oauth_token: "{{ oauth_token }}"

  # Fails before fix
  - name: Get information about the certificate
    community.digitalocean.digital_ocean_certificate_info:
      certificate_id: "{{ do_certificate_id }}"
      oauth_token: "{{ oauth_token }}"

  - name: Get information about all certificates
    community.digitalocean.digital_ocean_certificate_info:
      oauth_token: "{{ oauth_token }}"
```
