### PR TITLE
Return zone records when creating domain

### DIFF
--- a/changelogs/fragments/46-fix-domain-create-return-records.yaml
+++ b/changelogs/fragments/46-fix-domain-create-return-records.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - digital_ocean_domain - return zone records when creating a new zone (https://github.com/ansible-collections/community.digitalocean/issues/46).

--- a/plugins/modules/digital_ocean_domain.py
+++ b/plugins/modules/digital_ocean_domain.py
@@ -171,7 +171,7 @@ def run(module):
                 # Arguably, it's nice to see the records versus null, so, we'll just try a
                 # few times before giving up and returning null.
                 for i in range(5):
-                    if do_manager.domain_record()['domain']['zone_file'] != 'null':
+                    if do_manager.domain_record()['domain']['zone_file'] is not None:
                         module.exit_json(changed=True, domain=do_manager.domain_record()['domain'])
                     time.sleep(3)
                 module.exit_json(changed=True, domain=domain)

--- a/plugins/modules/digital_ocean_domain.py
+++ b/plugins/modules/digital_ocean_domain.py
@@ -75,7 +75,7 @@ EXAMPLES = r'''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.digitalocean.plugins.module_utils.digital_ocean import DigitalOceanHelper
-from time import sleep
+import time
 
 
 class DoManager(DigitalOceanHelper, object):

--- a/plugins/modules/digital_ocean_domain.py
+++ b/plugins/modules/digital_ocean_domain.py
@@ -77,6 +77,8 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.digitalocean.plugins.module_utils.digital_ocean import DigitalOceanHelper
 import time
 
+ZONE_FILE_ATTEMPTS = 5
+ZONE_FILE_SLEEP    = 3
 
 class DoManager(DigitalOceanHelper, object):
     def __init__(self, module):
@@ -170,10 +172,10 @@ def run(module):
                 #
                 # Arguably, it's nice to see the records versus null, so, we'll just try a
                 # few times before giving up and returning null.
-                for i in range(5):
+                for i in range(ZONE_FILE_ATTEMPTS):
                     if do_manager.domain_record()['domain']['zone_file'] is not None:
                         module.exit_json(changed=True, domain=do_manager.domain_record()['domain'])
-                    time.sleep(3)
+                    time.sleep(ZONE_FILE_SLEEP)
                 module.exit_json(changed=True, domain=domain)
         else:
             records = do_manager.all_domain_records()

--- a/plugins/modules/digital_ocean_domain.py
+++ b/plugins/modules/digital_ocean_domain.py
@@ -162,7 +162,8 @@ def core(module):
             if 'message' in domain:
                 module.fail_json(changed=False, msg=domain['message'])
             else:
-                module.exit_json(changed=True, domain=domain)
+                records = do_manager.all_domain_records()
+                module.exit_json(changed=True, domain=do_manager.domain_record())
         else:
             records = do_manager.all_domain_records()
             if module.params.get('ip'):

--- a/plugins/modules/digital_ocean_domain.py
+++ b/plugins/modules/digital_ocean_domain.py
@@ -80,6 +80,7 @@ import time
 ZONE_FILE_ATTEMPTS = 5
 ZONE_FILE_SLEEP = 3
 
+
 class DoManager(DigitalOceanHelper, object):
     def __init__(self, module):
         super(DoManager, self).__init__(module)

--- a/plugins/modules/digital_ocean_domain.py
+++ b/plugins/modules/digital_ocean_domain.py
@@ -78,7 +78,7 @@ from ansible_collections.community.digitalocean.plugins.module_utils.digital_oce
 import time
 
 ZONE_FILE_ATTEMPTS = 5
-ZONE_FILE_SLEEP    = 3
+ZONE_FILE_SLEEP = 3
 
 class DoManager(DigitalOceanHelper, object):
     def __init__(self, module):

--- a/plugins/modules/digital_ocean_domain.py
+++ b/plugins/modules/digital_ocean_domain.py
@@ -173,8 +173,11 @@ def run(module):
                 # Arguably, it's nice to see the records versus null, so, we'll just try a
                 # few times before giving up and returning null.
                 for i in range(ZONE_FILE_ATTEMPTS):
-                    if do_manager.domain_record()['domain']['zone_file'] is not None:
-                        module.exit_json(changed=True, domain=do_manager.domain_record()['domain'])
+                    record = do_manager.domain_record()
+                    if record is not None and 'domain' in record:
+                        domain = record['domain']
+                        if domain is not None and 'zone_file' in domain:
+                            module.exit_json(changed=True, domain=domain)
                     time.sleep(ZONE_FILE_SLEEP)
                 module.exit_json(changed=True, domain=domain)
         else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Return zone records even if creating a new domain, fixes #46 .

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
* digital_ocean_domain

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Here's the behavior in this branch:

```paste below
❯ doctl compute domain delete digitalocean.letsbuildthe.cloud -f

<deleted the domain>

❯ ansible-playbook -i localhost, -c local dns.yml -v
PLAY [localhost] **********************************************************************************************************************************************************

TASK [Create a domain] ****************************************************************************************************************************************************
Sunday 11 April 2021  10:23:22 -0400 (0:00:00.053)       0:00:00.053 **********
changed: [localhost] => changed=true
  ansible_facts:
    discovered_interpreter_python: /usr/bin/python3
  domain:
    domain:
      name: digitalocean.letsbuildthe.cloud
      ttl: 1800
      zone_file: |-
        $ORIGIN digitalocean.letsbuildthe.cloud.
        $TTL 1800
        digitalocean.letsbuildthe.cloud. IN SOA ns1.digitalocean.com. hostmaster.digitalocean.letsbuildthe.cloud. 1618151005 10800 3600 604800 1800
        digitalocean.letsbuildthe.cloud. 1800 IN NS ns1.digitalocean.com.
        digitalocean.letsbuildthe.cloud. 1800 IN NS ns2.digitalocean.com.
        digitalocean.letsbuildthe.cloud. 1800 IN NS ns3.digitalocean.com.


❯ ansible-playbook -i localhost, -c local dns.yml -v
PLAY [localhost] **********************************************************************************************************************************************************

TASK [Create a domain] ****************************************************************************************************************************************************
Sunday 11 April 2021  10:23:27 -0400 (0:00:00.052)       0:00:00.052 **********
ok: [localhost] => changed=false
  ansible_facts:
    discovered_interpreter_python: /usr/bin/python3
  domain:
    domain:
      name: digitalocean.letsbuildthe.cloud
      ttl: 1800
      zone_file: |-
        $ORIGIN digitalocean.letsbuildthe.cloud.
        $TTL 1800
        digitalocean.letsbuildthe.cloud. IN SOA ns1.digitalocean.com. hostmaster.digitalocean.letsbuildthe.cloud. 1618151005 10800 3600 604800 1800
        digitalocean.letsbuildthe.cloud. 1800 IN NS ns1.digitalocean.com.
        digitalocean.letsbuildthe.cloud. 1800 IN NS ns2.digitalocean.com.
        digitalocean.letsbuildthe.cloud. 1800 IN NS ns3.digitalocean.com.

PLAY RECAP ****************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

Here's the behavior out of `main` right now:

```
❯ ansible-playbook -i localhost, -c local dns.yml -v
Using /home/mark/.ansible.cfg as config file
[WARNING]: running playbook inside collection community.digitalocean

PLAY [localhost] **********************************************************************************************************************************************************

TASK [Create a domain] ****************************************************************************************************************************************************
Sunday 11 April 2021  10:28:48 -0400 (0:00:00.048)       0:00:00.048 **********
changed: [localhost] => changed=true
  ansible_facts:
    discovered_interpreter_python: /usr/bin/python3
  domain:
    name: digitalocean.letsbuildthe.cloud
    ttl: null
    zone_file: null

PLAY RECAP ****************************************************************************************************************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

Playbook run took 0 days, 0 hours, 0 minutes, 2 seconds
Sunday 11 April 2021  10:28:50 -0400 (0:00:01.987)       0:00:02.036 **********
===============================================================================
Create a domain ---------------------------------------------------------------------------------------------------------------------------------------------------- 1.99s
```