### PR TITLE
feat(inventory-plugin): filter droplets by tag during building inventory

### DIFF
--- a/changelogs/fragments/77-filter-droplets-by-tag.yml
+++ b/changelogs/fragments/77-filter-droplets-by-tag.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - digitalocean - filter droplets by tag in dynamic inventory plugin

--- a/changelogs/fragments/77-filter-droplets-by-tag.yml
+++ b/changelogs/fragments/77-filter-droplets-by-tag.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - digitalocean - filter droplets by tag in dynamic inventory plugin
+  - digitalocean - filter droplets by tag in dynamic inventory plugin (https://github.com/ansible-collections/community.digitalocean/pull/77)

--- a/plugins/inventory/digitalocean.py
+++ b/plugins/inventory/digitalocean.py
@@ -11,6 +11,7 @@ name: digitalocean
 author:
   - Janos Gerzson (@grzs)
   - Tadej Borovšak (@tadeboro)
+  - Tomasz Skręt (@krecik)
 short_description: DigitalOcean Inventory Plugin
 version_added: "1.1.0"
 description:
@@ -49,6 +50,11 @@ options:
       - networks
       - region
       - size_slug
+  filter_by_tag:
+    description:
+      - Filter droplets by tag
+    type: str
+    default: ''
   var_prefix:
     description:
       - Prefix of generated varible names (e.g. C(tags) -> C(do_tags))
@@ -80,6 +86,7 @@ attributes:
   - volume_ids
   - tags
   - region
+filter_by_tag: 'my-tag'
 keyed_groups:
   - key: do_region.slug
     prefix: 'region'
@@ -135,6 +142,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # build url
         pagination = self.get_option('pagination')
         url = 'https://api.digitalocean.com/v2/droplets?per_page=' + str(pagination)
+        # filter droplets by tag
+        filter_by_tag = self.get_option('filter_by_tag')
+        if filter_by_tag:
+            url += '&tag_name=' + str(filter_by_tag)
 
         # send request(s)
         self.req = Request(headers=headers)

--- a/tests/unit/plugins/inventory/test_digitalocean.py
+++ b/tests/unit/plugins/inventory/test_digitalocean.py
@@ -130,6 +130,14 @@ def get_option(option):
     }
     return options.get(option)
 
+def get_option_with_filter_tag(option):
+    options = {
+        'filter_by_tag': 'my-tag',
+        'var_prefix': 'do_',
+        'strict': False,
+    }
+    return options.get(option)
+
 
 def test_populate_hostvars(inventory, mocker):
     inventory._get_payload = mocker.MagicMock(side_effect=get_payload)
@@ -141,3 +149,12 @@ def test_populate_hostvars(inventory, mocker):
 
     assert host_foo.vars['do_id'] == 3164444
     assert host_bar.vars['do_size_slug'] == "s-1vcpu-1gb"
+
+def test_populate_hostvars_with_filter_by_tag(inventory, mocker):
+    inventory._get_payload = mocker.MagicMock(side_effect=get_payload)
+    inventory.get_option = mocker.MagicMock(side_effect=get_option_with_filter_tag)
+    inventory._populate()
+
+    host_foo = inventory.inventory.get_host('foo')
+
+    assert host_foo.vars['do_id'] == 3164444


### PR DESCRIPTION
##### SUMMARY
Filter droplets by tag name. Useful to use, to ex. filter over one tag and later split inventory by other tags.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Inventory plugin

##### ADDITIONAL INFORMATION
n/a