### PR TITLE
Fix documentation link for `digital_ocean_droplet_info`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Tested with the current Ansible 2.9 and 2.10 releases and the current developmen
 - [digital_ocean_domain_info](https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_domain_info_module.html) – Gather information about DigitalOcean Domains
 - [digital_ocean_domain_record](https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_domain_record.html) – Create and delete DigitalOcean Domain Records
 - [digital_ocean_droplet](https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_droplet_module.html) – Create and delete a DigitalOcean droplet
-- [digital_ocean_droplet_info](https;//docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_droplet_info.html) - Gather information about DigitalOcean Droplets
+- [digital_ocean_droplet_info](https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_droplet_info.html) - Gather information about DigitalOcean Droplets
 - [digital_ocean_firewall](https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_firewall_module.html) – Create and delete DigitalOcean firewalls
 - [digital_ocean_firewall_facts](https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_firewall_facts_module.html) – Gather information about DigitalOcean firewalls
 - [digital_ocean_firewall_info](https://docs.ansible.com/ansible/latest/collections/community/digitalocean/digital_ocean_firewall_info_module.html) – Gather information about DigitalOcean firewalls

--- a/changelogs/fragments/81-fix-document-link-digital-ocean-droplet-info.yml
+++ b/changelogs/fragments/81-fix-document-link-digital-ocean-droplet-info.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - digital_ocean_droplet_info - Fix documentation link for `digital_ocean_droplet_info` (https://github.com/ansible-collections/community.digitalocean/pull/81).


### PR DESCRIPTION
##### SUMMARY

I've just noticed the incorrect documentation link for `digital_ocean_droplet_info` while I'm comparing the documentations from ansible galaxy site to this repository.
