### PR TITLE
Issues 83 and 66

### DIFF
--- a/changelogs/fragments/83-droplet-inactive.yaml
+++ b/changelogs/fragments/83-droplet-inactive.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - digital_ocean_droplet - Fix Droplet inactive state (https://github.com/ansible-collections/community.digitalocean/issues/83).
+  - digital_ocean_droplet - Add integration tests for Droplet active and inactive states (https://github.com/ansible-collections/community.digitalocean/issues/66).

--- a/tests/integration/targets/digital_ocean_droplet/tasks/main.yml
+++ b/tests/integration/targets/digital_ocean_droplet/tasks/main.yml
@@ -40,6 +40,103 @@
       ansible.builtin.assert:
         that:
           - result.changed
+          - result.data is defined
+          - result.data.droplet is defined
+          - result.data.droplet.name is defined
+          - result.data.droplet.name == droplet_name
+          - result.data.droplet.status == "active"
+
+    - name: Give the cloud a minute to settle
+      ansible.builtin.pause:
+        minutes: 1
+
+    - name: Ensure Droplet is absent
+      community.digitalocean.digital_ocean_droplet:
+        oauth_token: "{{ do_api_key }}"
+        state: absent
+        name: "{{ droplet_name }}"
+        unique_name: true
+        region: "{{ do_region }}"
+        image: "{{ droplet_image }}"
+        size: "{{ droplet_size }}"
+      register: result
+
+    - name: Verify Droplet is absent
+      ansible.builtin.assert:
+        that:
+          - result.changed
+
+    - name: Give the cloud a minute to settle
+      ansible.builtin.pause:
+        minutes: 1
+
+    - name: Create the Droplet (active)
+      community.digitalocean.digital_ocean_droplet:
+        oauth_token: "{{ do_api_key }}"
+        state: active
+        name: "{{ droplet_name }}"
+        unique_name: true
+        region: "{{ do_region }}"
+        image: "{{ droplet_image }}"
+        size: "{{ droplet_size }}"
+        wait_timeout: 500
+      register: result
+
+    - name: Verify Droplet is present (and active)
+      ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.data is defined
+          - result.data.droplet is defined
+          - result.data.droplet.name is defined
+          - result.data.droplet.name == droplet_name
+          - result.data.droplet.status == "active"
+
+    - name: Give the cloud a minute to settle
+      ansible.builtin.pause:
+        minutes: 1
+
+    - name: Ensure Droplet is absent
+      community.digitalocean.digital_ocean_droplet:
+        oauth_token: "{{ do_api_key }}"
+        state: absent
+        name: "{{ droplet_name }}"
+        unique_name: true
+        region: "{{ do_region }}"
+        image: "{{ droplet_image }}"
+        size: "{{ droplet_size }}"
+      register: result
+
+    - name: Verify Droplet is absent
+      ansible.builtin.assert:
+        that:
+          - result.changed
+
+    - name: Give the cloud a minute to settle
+      ansible.builtin.pause:
+        minutes: 1
+
+    - name: Create the Droplet (inactive)
+      community.digitalocean.digital_ocean_droplet:
+        oauth_token: "{{ do_api_key }}"
+        state: inactive
+        name: "{{ droplet_name }}"
+        unique_name: true
+        region: "{{ do_region }}"
+        image: "{{ droplet_image }}"
+        size: "{{ droplet_size }}"
+        wait_timeout: 500
+      register: result
+
+    - name: Verify Droplet is present (and off)
+      ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.data is defined
+          - result.data.droplet is defined
+          - result.data.droplet.name is defined
+          - result.data.droplet.name == droplet_name
+          - result.data.droplet.status == "off"
 
     - name: Give the cloud a minute to settle
       ansible.builtin.pause:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Droplet creation for `state: inactive` was broken (Droplet was `active`); added integration tests to verify. Fixed #83 and #66.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
* `digital_ocean_droplet`
