### PR TITLE
Fix ssh traceback issue (#68)

### DIFF
--- a/changelogs/fragments/68-fix-sshkey-traceback.yaml
+++ b/changelogs/fragments/68-fix-sshkey-traceback.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - digital_ocean_sshkey - Fixed SSH Key Traceback Issue (https://github.com/ansible-collections/community.digitalocean/issues/68).

--- a/plugins/modules/digital_ocean_sshkey.py
+++ b/plugins/modules/digital_ocean_sshkey.py
@@ -172,7 +172,7 @@ def core(module):
     rest = Rest(module, {'Authorization': 'Bearer {0}'.format(api_token),
                          'Content-type': 'application/json'})
 
-    fingerprint = fingerprint or ssh_key_fingerprint(ssh_pub_key)
+    fingerprint = fingerprint or ssh_key_fingerprint(module,ssh_pub_key)
     response = rest.get('account/keys/{0}'.format(fingerprint))
     status_code = response.status_code
     json = response.json
@@ -238,10 +238,13 @@ def core(module):
             status_code, response.json['message']))
 
 
-def ssh_key_fingerprint(ssh_pub_key):
-    key = ssh_pub_key.split(None, 2)[1]
-    fingerprint = hashlib.md5(base64.b64decode(key)).hexdigest()
-    return ':'.join(a + b for a, b in zip(fingerprint[::2], fingerprint[1::2]))
+def ssh_key_fingerprint(module, ssh_pub_key):
+    try:
+        key = ssh_pub_key.split(None, 2)[1]
+        fingerprint = hashlib.md5(base64.b64decode(key)).hexdigest()
+        return ':'.join(a + b for a, b in zip(fingerprint[::2], fingerprint[1::2]))
+    except:
+        module.fail_json(msg="This does not appear to be a valid public key. Please verify the format and value provided in ssh_public_key.")
 
 
 def main():

--- a/plugins/modules/digital_ocean_sshkey.py
+++ b/plugins/modules/digital_ocean_sshkey.py
@@ -172,7 +172,7 @@ def core(module):
     rest = Rest(module, {'Authorization': 'Bearer {0}'.format(api_token),
                          'Content-type': 'application/json'})
 
-    fingerprint = fingerprint or ssh_key_fingerprint(module,ssh_pub_key)
+    fingerprint = fingerprint or ssh_key_fingerprint(module, ssh_pub_key)
     response = rest.get('account/keys/{0}'.format(fingerprint))
     status_code = response.status_code
     json = response.json
@@ -243,7 +243,7 @@ def ssh_key_fingerprint(module, ssh_pub_key):
         key = ssh_pub_key.split(None, 2)[1]
         fingerprint = hashlib.md5(base64.b64decode(key)).hexdigest()
         return ':'.join(a + b for a, b in zip(fingerprint[::2], fingerprint[1::2]))
-    except:
+    except IndexError:
         module.fail_json(msg="This does not appear to be a valid public key. Please verify the format and value provided in ssh_public_key.")
 
 


### PR DESCRIPTION
##### SUMMARY
This resolves an issue that reports a traceback instead of a useful error message when providing an invalid `ssh_public_key` while using the `digital_ocean_sshkey` module. This stemmed from the way that the code was attempting to parse the provided key. There may be a better way to determine if a string is a public key that we can refine in the future, but for now this PR just captures the error and let's the user know what needs to be investigated.

Fixes #68 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
digital_ocean_sshkey

##### ADDITIONAL INFORMATION
N/A
