### PR TITLE
Fix snapshot_info module 

### DIFF
--- a/changelogs/fragments/92-snapshot-info-fix-get-by-id.yaml
+++ b/changelogs/fragments/92-snapshot-info-fix-get-by-id.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - digital_ocean_snapshot_info - Fix lookup of snapshot_info by_id (https://github.com/ansible-collections/community.digitalocean/issues/92).

--- a/plugins/modules/digital_ocean_snapshot_info.py
+++ b/plugins/modules/digital_ocean_snapshot_info.py
@@ -83,6 +83,7 @@ RETURN = r'''
 data:
     description: DigitalOcean snapshot information
     returned: success
+    elements: dict
     type: list
     sample: [
         {
@@ -111,7 +112,7 @@ def core(module):
 
     rest = DigitalOceanHelper(module)
 
-    base_url = 'snapshots?'
+    base_url = 'snapshots'
     snapshot = []
 
     if snapshot_type == 'by_id':
@@ -125,9 +126,11 @@ def core(module):
         snapshot.extend(response.json["snapshots"])
     else:
         if snapshot_type == 'droplet':
-            base_url += "resource_type=droplet&"
+            base_url += "?resource_type=droplet&"
         elif snapshot_type == 'volume':
-            base_url += "resource_type=volume&"
+            base_url += "?resource_type=volume&"
+        else:
+            base_url += "?"
 
         snapshot = rest.get_paginated_data(base_url=base_url, data_key_name='snapshots')
     module.exit_json(changed=False, data=snapshot)

--- a/plugins/modules/digital_ocean_snapshot_info.py
+++ b/plugins/modules/digital_ocean_snapshot_info.py
@@ -121,7 +121,7 @@ def core(module):
 
         if status_code != 200:
             module.fail_json(msg="Failed to fetch snapshot information due to error : %s" % response.json['message'])
-        
+
         snapshot.extend(response.json["snapshots"])
     else:
         if snapshot_type == 'droplet':

--- a/plugins/modules/digital_ocean_snapshot_info.py
+++ b/plugins/modules/digital_ocean_snapshot_info.py
@@ -121,8 +121,8 @@ def core(module):
 
         if status_code != 200:
             module.fail_json(msg="Failed to fetch snapshot information due to error : %s" % response.json['message'])
-
-        snapshot.extend(response.json["snapshot"])
+        
+        snapshot.extend(response.json["snapshots"])
     else:
         if snapshot_type == 'droplet':
             base_url += "resource_type=droplet&"

--- a/tests/integration/targets/digital_ocean_snapshot_info/tasks/main.yml
+++ b/tests/integration/targets/digital_ocean_snapshot_info/tasks/main.yml
@@ -56,4 +56,3 @@
       ansible.builtin.assert:
         that:
           - result.failed
-

--- a/tests/integration/targets/digital_ocean_snapshot_info/tasks/main.yml
+++ b/tests/integration/targets/digital_ocean_snapshot_info/tasks/main.yml
@@ -8,10 +8,10 @@
         - do_api_key is not defined
         - do_api_key | length == 0
 
-    - name: Gather information about snapshots
+    - name: Gather information about snapshots (all)
       community.digitalocean.digital_ocean_snapshot_info:
         oauth_token: "{{ do_api_key }}"
-        snapshot_type: "{{ snapshot_type }}"
+        snapshot_type: "all"
       register: result
 
     - name: Verify snapshot info fetched
@@ -19,3 +19,41 @@
         that:
           - not result.changed
           - result.data is defined
+
+    - name: Gather information about  snapshots (droplets)
+      community.digitalocean.digital_ocean_snapshot_info:
+        oauth_token: "{{ do_api_key }}"
+        snapshot_type: "droplet"
+      register: result
+
+    - name: Verify snapshot info fetched
+      ansible.builtin.assert:
+        that:
+          - not result.changed
+          - result.data is defined
+
+    - name: Gather information about snapshots (volumes)
+      community.digitalocean.digital_ocean_snapshot_info:
+        oauth_token: "{{ do_api_key }}"
+        snapshot_type: "volume"
+      register: result
+
+    - name: Verify snapshot info fetched
+      ansible.builtin.assert:
+        that:
+          - not result.changed
+          - result.data is defined
+
+    - name: Gather information about snapshots (by_id)
+      community.digitalocean.digital_ocean_snapshot_info:
+        oauth_token: "{{ do_api_key }}"
+        snapshot_type: "by_id"
+        snapshot_id: "12345678"
+      ignore_errors: true
+      register: result
+
+    - name: Verify that a non-existent snapshot failed
+      ansible.builtin.assert:
+        that:
+          - result.failed
+


### PR DESCRIPTION
##### SUMMARY

This PR fixes the functionality of the `digital_ocean_snapshot_info` to be able to lookup a snapshot with `snapshot_type: "by_id"`

Fixes #92 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`digital_ocean_snapshot_info`

##### ADDITIONAL INFORMATION
The current implementation fails because it is looking for the wrong key (`snapshot` vs. `snapshots`). Once this was resolved, it was then necessary to change some of the `base_url` logic due to when a lookup by id didn't match a valid id, it returned everything instead of returning the expected error.

Integration tests have been added to test out the expected functionality.
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
