### PR TITLE
Actually activate inventory caching

### DIFF
--- a/changelogs/fragments/97-wire-up-inventory-cache.yml
+++ b/changelogs/fragments/97-wire-up-inventory-cache.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - digitalocean inventory plugin - wire up advertised caching functionality
+    (https://github.com/ansible-collections/community.digitalocean/pull/97).

--- a/tests/unit/plugins/inventory/test_digitalocean.py
+++ b/tests/unit/plugins/inventory/test_digitalocean.py
@@ -28,7 +28,8 @@ def test_verify_file_bad_config(inventory):
     assert inventory.verify_file('digitalocean_foobar.yml') is False
 
 
-def get_payload():
+@pytest.fixture()
+def payload():
     return [
         {
             "id": 3164444,
@@ -136,10 +137,10 @@ def get_option(option):
     return options.get(option)
 
 
-def test_populate_hostvars(inventory, mocker):
-    inventory._get_payload = mocker.MagicMock(side_effect=get_payload)
+def test_populate_hostvars(inventory, payload, mocker):
     inventory.get_option = mocker.MagicMock(side_effect=get_option)
-    inventory._populate()
+
+    inventory._populate(payload)
 
     host_foo = inventory.inventory.get_host('foo')
     host_bar = inventory.inventory.get_host('bar')
@@ -184,10 +185,9 @@ def get_option_with_filters(option):
     return options.get(option)
 
 
-def test_populate_hostvars_with_filters(inventory, mocker):
-    inventory._get_payload = mocker.MagicMock(side_effect=get_payload)
+def test_populate_hostvars_with_filters(inventory, payload, mocker):
     inventory.get_option = mocker.MagicMock(side_effect=get_option_with_filters)
-    inventory._populate()
+    inventory._populate(payload)
 
     host_foo = inventory.inventory.get_host('foo')
     host_bar = inventory.inventory.get_host('bar')


### PR DESCRIPTION
##### SUMMARY

The inventory plugin advertises support for caching, but the implementation was missing the required pieces to make it work properly.

This commit split the inventory construction into two stages. The first stage is responsible for fetching remote data (interacting with the DigitalOcean's API). The second stage extracts the relevant data from the API responses and populated the inventory.

Caching support then came almost for free. All we had to do is only fetch data if:

 1. User does not want to use cache at all.
 2. User does use cache and wants data refreshed.
 3. User does use cache, but the cache is empty.

Some additional logic makes sure we write the data to cache if data refresh is requested, but nothing too complex.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`community.digitalocean.digitalocean` inventory plugin