### PR TITLE
Support templating of the API token

### DIFF
--- a/changelogs/fragments/98-api-token-command.yml
+++ b/changelogs/fragments/98-api-token-command.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - digitalocean - support templates in API tokens when using the dynamic inventory plugin (https://github.com/ansible-collections/community.digitalocean/pull/98).


### PR DESCRIPTION
##### SUMMARY
This PR adds support for templates in the API token field. This mechanism allows retrieving the password from arbitrary sources (for example, a password manager).

##### TODO
- [x] Add documentation.
- [x] Add tests.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Inventory plugin

##### ADDITIONAL INFORMATION
Example script `get-do-token.sh` that just writes the API token to stdout:
```sh
#!/usr/bin/env sh

# You can do whatever you want here.
echo 'your-api-token-here'
```
Inventory config `inventory_digitalocean.yml`, referencing the script:
```yml
plugin: community.digitalocean.digitalocean
api_token: '{{ lookup("pipe", "./get-do-token.sh") }}'
```