### PR TITLE
Fix Droplet present state (with wait)

### DIFF
--- a/changelogs/fragments/116-droplet-present-wait.yaml
+++ b/changelogs/fragments/116-droplet-present-wait.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - digital_ocean_droplet - state `present` with `wait` was not waiting (https://github.com/ansible-collections/community.digitalocean/issues/116).

--- a/plugins/modules/digital_ocean_droplet.py
+++ b/plugins/modules/digital_ocean_droplet.py
@@ -344,7 +344,7 @@ class DODroplet(object):
             droplet_id = droplet_data.get("id", None)
             if droplet_id is not None:
                 if self.wait:
-                    if state == "active":
+                    if state == "present" or state == "active":
                         json_data = self.ensure_power_on(droplet_id)
                     if state == "inactive":
                         json_data = self.ensure_power_off(droplet_id)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
State `present` with `wait` should wait for power on; fixes #116.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
* digital_ocean_droplet

