### PR TITLE
Respect the TRANSFORM_INVALID_GROUP_CHARS setting

### DIFF
--- a/changelogs/fragments/138-group-name-transformations.yaml
+++ b/changelogs/fragments/138-group-name-transformations.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - digitalocean inventory - respect the TRANSFORM_INVALID_GROUP_CHARS
+    configuration setting
+    (https://github.com/ansible-collections/community.digitalocean/pull/138).

--- a/plugins/inventory/digitalocean.py
+++ b/plugins/inventory/digitalocean.py
@@ -110,6 +110,7 @@ filters:
 import re
 import json
 from ansible.errors import AnsibleError, AnsibleParserError
+from ansible.inventory.group import to_safe_group_name
 from ansible.module_utils._text import to_native
 from ansible.module_utils.urls import Request
 from ansible.module_utils.six.moves.urllib.error import URLError, HTTPError
@@ -119,6 +120,13 @@ from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cachea
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     NAME = 'community.digitalocean.digitalocean'
+
+    # Constructable methods use the following function to construct group names. By
+    # default, characters that are not valid in python variables, are always replaced by
+    # underscores. We are overriding this with a function that respects the
+    # TRANSFORM_INVALID_GROUP_CHARS configuration option and allows users to control the
+    # behavior.
+    _sanitize_group_name = staticmethod(to_safe_group_name)
 
     def verify_file(self, path):
         valid = False


### PR DESCRIPTION
Up until now, the inventory plugin always replaced invalid characters in group names, which can be a bit surprising when we generate groups on things such as droplet tags. To make things even more confusing, the TRANSFORM_INVALID_GROUP_CHARS configuration option is completely ignored, giving users no way of preserving original names.

This commit replaces the default group name sanitization function with the one that respects the TRANSFORM_INVALID_GROUP_CHARS configuration option.

Fixes #133 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Inventory plugin