### PR TITLE
Ensure active before power on

### DIFF
--- a/changelogs/fragments/150-droplet-active-power-on.yaml
+++ b/changelogs/fragments/150-droplet-active-power-on.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - digital_ocean_droplet - ensure "active" state before issuing "power on" action (https://github.com/ansible-collections/community.digitalocean/issues/150)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Might be related to #150. In any event, ensuring "active" (versus "new") seems like a good idea before triggering the "power on" action.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
* digital_ocean_droplet
