### PR TITLE
Adding taints, autoscale, min_nodes and max_nodes to node_pools

### DIFF
--- a/changelogs/fragments/157-doks-auto-scale.yaml
+++ b/changelogs/fragments/157-doks-auto-scale.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - digital_ocean_kubernetes - adding the C(taints), C(auto_scale), C(min_nodes) and C(max_nodes) parameters to the C(node_pools) definition (https://github.com/ansible-collections/community.digitalocean/issues/157).

--- a/plugins/modules/digital_ocean_kubernetes.py
+++ b/plugins/modules/digital_ocean_kubernetes.py
@@ -94,12 +94,36 @@ options:
       labels:
         type: dict
         description: An object containing a set of Kubernetes labels. The keys are user-defined.
+      taints:
+        type: list
+        description:
+          - An array of taints to apply to all nodes in a pool.
+          - Taints will automatically be applied to all existing nodes and any subsequent nodes added to the pool.
+          - When a taint is removed, it is removed from all nodes in the pool.
+      auto_scale:
+        type: bool
+        description:
+          - A boolean value indicating whether auto-scaling is enabled for this node pool.
+      min_nodes:
+        type: int
+        description:
+          - The minimum number of nodes that this node pool can be auto-scaled to.
+          - The value will be C(0) if C(auto_scale) is set to C(false).
+      max_nodes:
+        type: int
+        description:
+          - The maximum number of nodes that this node pool can be auto-scaled to.
+          - The value will be C(0) if C(auto_scale) is set to C(false).
     default:
       - name: worker-pool
         size: s-1vcpu-2gb
         count: 1
         tags: []
         labels: {}
+        taints: []
+        auto_scale: false
+        min_nodes: 0
+        max_nodes: 0
   vpc_uuid:
     description:
       - A string specifying the UUID of the VPC to which the Kubernetes cluster will be assigned.
@@ -429,6 +453,10 @@ def main():
                         "count": 1,
                         "tags": [],
                         "labels": {},
+                        "taints": [],
+                        "auto_scale": False,
+                        "min_nodes": 0,
+                        "max_nodes": 0,
                     }
                 ],
             ),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #157.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
* digital_ocean_kubernetes

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Seems to work just fine:

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
❯ doctl kubernetes cluster get 70098f48-d3fb-41db-9aa3-3181d61e2cb1 -o json | jq -r '.[0].node_pools'
[
  {
    "id": "de2a8eb3-740a-4a0e-9ab6-0b0ad11173e0",
    "name": "hacktoberfest-workers",
    "size": "s-1vcpu-2gb",
    "count": 1,
    "tags": [
      "k8s",
      "k8s:70098f48-d3fb-41db-9aa3-3181d61e2cb1",
      "k8s:worker"
    ],
    "auto_scale": true,
    "min_nodes": 1,
    "max_nodes": 3,
    "nodes": [
      {
        "id": "528ee3e6-ef68-44f1-9864-c0d50edae628",
        "name": "hacktoberfest-workers-81yxu",
        "status": {
          "state": "running"
        },
        "droplet_id": "263706237",
        "created_at": "2021-09-07T23:37:27Z",
        "updated_at": "2021-09-07T23:41:41Z"
      }
    ]
  }
]
```

I used this play:

```ansible
    - name: Create a new DigitalOcean Kubernetes cluster in New York 1
      community.digitalocean.digital_ocean_kubernetes:
        state: present
        oauth_token: "{{ lookup('env', 'DO_API_TOKEN') }}"
        name: hacktoberfest
        region: nyc1
        node_pools:
          - name: hacktoberfest-workers
            size: s-1vcpu-2gb
            count: 1
            auto_scale: true
            min_nodes: 1
            max_nodes: 3
        return_kubeconfig: yes
        wait_timeout: 900
      register: my_cluster
```
