### PR TITLE
Fix returned data for already present floating IP

### DIFF
--- a/changelogs/fragments/162-floating-ip-data-idempotency.yaml
+++ b/changelogs/fragments/162-floating-ip-data-idempotency.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - digital_ocean_floating_ip - make floating ip return data idempotent (https://github.com/ansible-collections/community.digitalocean/pull/162).

--- a/plugins/modules/digital_ocean_floating_ip.py
+++ b/plugins/modules/digital_ocean_floating_ip.py
@@ -329,7 +329,7 @@ def create_floating_ips(module, rest):
                             ip = floating_ip.get("ip", None)
                             if ip is not None:
                                 module.exit_json(
-                                    changed=False, data={"floating_ip": ip}
+                                    changed=False, data={"floating_ip": floating_ip}
                                 )
                             else:
                                 module.fail_json(


### PR DESCRIPTION
##### SUMMARY
Floating IP module is idempotent when a Droplet ID is provided. However, the returned data structure is different between the run when the IP is created and the run it is already present. This pull-request fixes the returned data for the state that the floating IP is present. Please see the output below.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`community.digitalocean.digital_ocean_floating_ip`

##### ADDITIONAL INFORMATION
The test:
```yaml
  - name: Create floating IP address
    community.digitalocean.digital_ocean_floating_ip:
      state: present
      droplet_id: "123456"
    register: floating_ip
  - debug:
      var: floating_ip
```

Output when floating IP is created:
```
TASK [Create floating IP address] **********************************************
changed: [localhost]

TASK [debug] *******************************************************************
ok: [localhost] => {
    "floating_ip": {
        "changed": true,
        "data": {
            "floating_ip": {
                "droplet": null,
                "ip": "12.34.56.78",
                "locked": true,
                "region": {
                    ... (omitted)
                }
            },
            "links": {}
        },
        "failed": false
    }
}

```

Output when floating IP is existing (before the PR):
```
TASK [Create floating IP address] **********************************************
ok: [localhost]

TASK [debug] *******************************************************************
ok: [localhost] => {
    "floating_ip": {
        "changed": false,
        "data": {
            "floating_ip": "12.34.56.78"
        },
        "failed": false
    }
}
```

Output when floating IP is existing (after the PR):
```
TASK [Create floating IP address] **********************************************
ok: [localhost]

TASK [debug] *******************************************************************
ok: [localhost] => {
    "floating_ip": {
        "changed": false,
        "data": {
            "floating_ip": {
                "droplet": {
                    ... (omitted)
                },
                "ip": "12.34.56.78",
                "locked": false,
                "region": {
                    ... (omitted)
                }
            }
        },
        "failed": false
    }
}
```
