### PR TITLE
Improving integration testing (approval-based on PRs)

### DIFF
--- a/.github/workflows/ansible-test-integration.yml
+++ b/.github/workflows/ansible-test-integration.yml
@@ -58,7 +58,6 @@ jobs:
       # ansible-test support producing code coverage date
       - name: Generate coverage report
         run: ansible-test coverage xml -v --requirements --group-by command --group-by version
-        working-directory: ./ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}
 
       # See the reports at https://app.codecov.io/gh/ansible-collections/community.digitalocean
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/ansible-test-integration.yml
+++ b/.github/workflows/ansible-test-integration.yml
@@ -14,7 +14,7 @@ env:
   COLLECTION_NAME: digitalocean
 
 concurrency:
-  group: cloud_integration_tests
+  group: cloud-integration-tests
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/pull-request-integration.yml
+++ b/.github/workflows/pull-request-integration.yml
@@ -1,0 +1,95 @@
+name: pull-request-integration
+
+on:
+  pull_request_target:
+    branches: [ main ]
+
+env:
+  NAMESPACE: community
+  COLLECTION_NAME: digitalocean
+
+concurrency:
+  group: cloud-integration-tests
+  cancel-in-progress: false
+
+jobs:
+
+  approve:
+    name: approve
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: approve
+        run: echo All pull requests need to be approved before running the integration tests.
+
+  secret:
+    name: secret
+    needs: [ approve ]
+    environment: integration
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Write secret
+        shell: bash
+        run: echo "export DO_API_KEY='${{ secrets.DO_API_KEY }}'" >secret
+
+      - name: Upload secret
+        uses: actions/upload-artifact@v2
+        with:
+          name: secret
+          path: secret
+          retention-days: 0
+
+  integration:
+
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}
+
+    steps:
+
+      - name: Download secret
+        uses: actions/download-artifact@v2
+        with:
+          name: secret
+
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          path: ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}
+          ref: ${{ github.event.pull_request.head.sha }} # Check out the pull request
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install ansible-base (${{ matrix.ansible }})
+        run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
+
+      - name: Install ansible_collections.community.general
+        run: ansible-galaxy collection install community.general -p ../../
+
+      - name: Configure integration test run secrets
+        run: |
+          source ../../../secret
+          ./tests/utils/render.sh \
+            ./tests/integration/integration_config.yml.template \
+              > ./tests/integration/integration_config.yml
+
+      # Run the integration tests
+      - name: Run integration test
+        run: ansible-test integration -v --color --retry-on-error --continue-on-error --diff --python ${{ matrix.python }} --docker --coverage
+
+        # ansible-test support producing code coverage date
+      - name: Generate coverage report
+        run: ansible-test coverage xml -v --requirements --group-by command --group-by version
+
+      # See the reports at https://app.codecov.io/gh/ansible-collections/community.digitalocean
+      - uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: false


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
By using `pull_request_target` and `environment` and `artifact`, I believe that this gives us a safe way (approval-based) to run integration tests on pull requests which doesn't expose secrets. I'd definitely like an audit of this, I'm by no means an expert in Github Workflows. I'd love to see integration tests running on pull requests, if possible (it'd make it much easier for reviewers to feel comfortable that things are working correctly). This will require setting up an "Environment" in this project and adding the API key secret to it.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Github Workflow `pull-request-integration` (new)
