### PR TITLE
Adding Project support

### DIFF
--- a/changelogs/fragments/171-add-project-support.yaml
+++ b/changelogs/fragments/171-add-project-support.yaml
@@ -1,0 +1,7 @@
+minor_changes:
+  - digital_ocean_block_storage - adding Project support (https://github.com/ansible-collections/community.digitalocean/issues/171).
+  - digital_ocean_database - adding Project support (https://github.com/ansible-collections/community.digitalocean/issues/171).
+  - digital_ocean_domain - adding Project support (https://github.com/ansible-collections/community.digitalocean/issues/171).
+  - digital_ocean_droplet - adding Project support (https://github.com/ansible-collections/community.digitalocean/issues/171).
+  - digital_ocean_floating_ip - adding Project support (https://github.com/ansible-collections/community.digitalocean/issues/171).
+  - digital_ocean_load_balancer - adding Project support (https://github.com/ansible-collections/community.digitalocean/issues/171).

--- a/plugins/module_utils/digital_ocean.py
+++ b/plugins/module_utils/digital_ocean.py
@@ -258,7 +258,7 @@ class DigitalOceanProjects:
         json = response.json
         if status_code != 200:
             message = json.get("message", "No error message returned")
-            return "", "Unable to assign resource {0} to project {1} [HTTP {3}: {4}]".format(urn, project_name, status_code, message), []
+            return "", "Unable to assign resource {0} to project {1} [HTTP {2}: {3}]".format(urn, project_name, status_code, message), []
 
         resources = json.get("resources", [])
         if len(resources) == 0:

--- a/plugins/module_utils/digital_ocean.py
+++ b/plugins/module_utils/digital_ocean.py
@@ -161,3 +161,59 @@ class DigitalOceanHelper:
             self.module.fail_json(msg=msg)
 
         return ret_data
+
+
+class DigitalOceanProjects:
+
+    def __init__(self, module, rest):
+        self.module = module
+        self.rest = rest
+        self.get_all_projects()
+        # self.projects = self.rest.get_paginated_data(base_url="projects?", data_key_name="projects")
+        # [{'id': 'c296b5ec-fb4d-423a-bcb2-20362a3e64f5', 'owner_uuid': '6559a5d2646ac0956dec5379d04fec698b6ea13a', 'owner_id': 3097135, 'name': 'mamercad', 'description': 'Update your project information under Settings', 'purpose': '', 'environment': '', 'is_default': True, 'created_at': '2019-07-28T20:43:15Z', 'updated_at': '2019-07-28T20:43:15Z'}]
+        # raise Exception("got here")
+
+    def get_all_projects(self):
+        self.projects = self.rest.get_paginated_data(base_url="projects?", data_key_name="projects")
+
+    def get_default(self):
+        project = [project for project in self.projects if project.get("is_default", False)]
+        if len(project) == 0:
+            self.module.fail_json(msg="Unexpected error; no default project found")
+        if len(project) > 1:
+            self.module.fail_json(msg="Unexpected error; more than one default project")
+        return project[0]
+
+    def get_by_id(self, id):
+        project = [project for project in self.projects if project.get("id") == id]
+        if len(project) == 0:
+            self.module.fail_json(msg="No project with id {0} found".format(id))
+        elif len(project) > 1:
+            self.module.fail_json(msg="Unexpected error; more than one project with the same id")
+        return project[0]
+
+    def get_by_name(self, name):
+        project = [project for project in self.projects if project.get("name") == name]
+        if len(project) == 0:
+            self.module.fail_json(msg="No project with name {0} found".format(name))
+        elif len(project) > 1:
+            self.module.fail_json(msg="Unexpected error; more than one project with the same name")
+        return project[0]
+
+    def assign_to_project(self, project_name, urn):
+        # urn e.g. do:volume:volume-id
+
+        project = self.get_by_name(project_name)
+        if project == {}:
+            self.module.fail_json(msg="No project named {0} found".format(project_name))
+
+        project_id = project.get("id", None)
+        if project_id is None:
+            self.module.fail_json(msg="Unexpected error; missing project id for {0}".format(project_name))
+
+        data = { "resources": [urn] }
+        response = self.rest.post("projects/{0}/resources".format(project_id), data=data)
+        status = response.status_code
+        json = response.json
+        if status != 200:
+            self.module.fail_json(msg="Unable to assign resource to project: {0}".format(json["message"]))

--- a/plugins/module_utils/digital_ocean.py
+++ b/plugins/module_utils/digital_ocean.py
@@ -164,7 +164,6 @@ class DigitalOceanHelper:
 
 
 class DigitalOceanProjects:
-
     def __init__(self, module, rest):
         self.module = module
         self.rest = rest
@@ -172,7 +171,9 @@ class DigitalOceanProjects:
 
     def get_all_projects(self):
         """Fetches all projects."""
-        self.projects = self.rest.get_paginated_data(base_url="projects?", data_key_name="projects")
+        self.projects = self.rest.get_paginated_data(
+            base_url="projects?", data_key_name="projects"
+        )
 
     def get_default(self):
         """Fetches the default project.
@@ -181,7 +182,9 @@ class DigitalOceanProjects:
         error_message -- project fetch error message (or "" if no error)
         project -- project dictionary representation (or {} if error)
         """
-        project = [project for project in self.projects if project.get("is_default", False)]
+        project = [
+            project for project in self.projects if project.get("is_default", False)
+        ]
         if len(project) == 0:
             return "Unexpected error; no default project found", {}
         if len(project) > 1:
@@ -250,21 +253,48 @@ class DigitalOceanProjects:
 
         project_id = project.get("id", None)
         if not project_id:
-            return "", "Unexpected error; cannot find project id for {0}".format(project_name), {}
+            return (
+                "",
+                "Unexpected error; cannot find project id for {0}".format(project_name),
+                {},
+            )
 
         data = {"resources": [urn]}
-        response = self.rest.post("projects/{0}/resources".format(project_id), data=data)
+        response = self.rest.post(
+            "projects/{0}/resources".format(project_id), data=data
+        )
         status_code = response.status_code
         json = response.json
         if status_code != 200:
             message = json.get("message", "No error message returned")
-            return "", "Unable to assign resource {0} to project {1} [HTTP {2}: {3}]".format(urn, project_name, status_code, message), {}
+            return (
+                "",
+                "Unable to assign resource {0} to project {1} [HTTP {2}: {3}]".format(
+                    urn, project_name, status_code, message
+                ),
+                {},
+            )
 
         resources = json.get("resources", [])
         if len(resources) == 0:
-            return "", "Unexpected error; no resources returned (but assignment was successful)", {}
+            return (
+                "",
+                "Unexpected error; no resources returned (but assignment was successful)",
+                {},
+            )
         if len(resources) > 1:
-            return "", "Unexpected error; more than one resource returned (but assignment was successful)", {}
+            return (
+                "",
+                "Unexpected error; more than one resource returned (but assignment was successful)",
+                {},
+            )
 
-        status = resources[0].get("status", "Unexpected error; no status returned (but assignment was successful)")
-        return status, "Assigned {0} to project {1}".format(urn, project_name), resources[0]
+        status = resources[0].get(
+            "status",
+            "Unexpected error; no status returned (but assignment was successful)",
+        )
+        return (
+            status,
+            "Assigned {0} to project {1}".format(urn, project_name),
+            resources[0],
+        )

--- a/plugins/module_utils/digital_ocean.py
+++ b/plugins/module_utils/digital_ocean.py
@@ -230,6 +230,19 @@ class DigitalOceanProjects:
 
         Notes:
         For URN examples, see https://docs.digitalocean.com/reference/api/api-reference/#tag/Project-Resources
+
+        Projects resources are identified by uniform resource names or URNs.
+        A valid URN has the following format: do:resource_type:resource_id.
+
+        The following resource types are supported:
+        Resource Type  | Example URN
+        Database       | do:dbaas:83c7a55f-0d84-4760-9245-aba076ec2fb2
+        Domain         | do:domain:example.com
+        Droplet        | do:droplet:4126873
+        Floating IP    | do:floatingip:192.168.99.100
+        Load Balancer  | do:loadbalancer:39052d89-8dd4-4d49-8d5a-3c3b6b365b5b
+        Space          | do:space:my-website-assets
+        Volume         | do:volume:6fc4c277-ea5c-448a-93cd-dd496cfef71f
         """
         error_message, project = self.get_by_name(project_name)
         if not project:

--- a/plugins/module_utils/digital_ocean.py
+++ b/plugins/module_utils/digital_ocean.py
@@ -226,7 +226,7 @@ class DigitalOceanProjects:
         Returns:
         assign_status -- ok, not_found, assigned, already_assigned, service_down
         error_message -- assignment error message (empty on success)
-        resources -- resources assigned (or [] if error)
+        resources -- resources assigned (or {} if error)
 
         Notes:
         For URN examples, see https://docs.digitalocean.com/reference/api/api-reference/#tag/Project-Resources
@@ -246,11 +246,11 @@ class DigitalOceanProjects:
         """
         error_message, project = self.get_by_name(project_name)
         if not project:
-            return "", error_message, []
+            return "", error_message, {}
 
         project_id = project.get("id", None)
         if not project_id:
-            return "", "Unexpected error; cannot find project id for {0}".format(project_name), []
+            return "", "Unexpected error; cannot find project id for {0}".format(project_name), {}
 
         data = {"resources": [urn]}
         response = self.rest.post("projects/{0}/resources".format(project_id), data=data)
@@ -258,13 +258,13 @@ class DigitalOceanProjects:
         json = response.json
         if status_code != 200:
             message = json.get("message", "No error message returned")
-            return "", "Unable to assign resource {0} to project {1} [HTTP {2}: {3}]".format(urn, project_name, status_code, message), []
+            return "", "Unable to assign resource {0} to project {1} [HTTP {2}: {3}]".format(urn, project_name, status_code, message), {}
 
         resources = json.get("resources", [])
         if len(resources) == 0:
-            return "", "Unexpected error; no resources returned (but assignment was successful)", []
+            return "", "Unexpected error; no resources returned (but assignment was successful)", {}
         if len(resources) > 1:
-            return "", "Unexpected error; more than one resource returned (but assignment was successful)", []
+            return "", "Unexpected error; more than one resource returned (but assignment was successful)", {}
 
         status = resources[0].get("status", "Unexpected error; no status returned (but assignment was successful)")
         return status, "Assigned {0} to project {1}".format(urn, project_name), resources[0]

--- a/plugins/module_utils/digital_ocean.py
+++ b/plugins/module_utils/digital_ocean.py
@@ -239,7 +239,7 @@ class DigitalOceanProjects:
         if not project_id:
             return "", "Unexpected error; cannot find project id for {0}".format(project_name), []
 
-        data = { "resources": [urn] }
+        data = {"resources": [urn]}
         response = self.rest.post("projects/{0}/resources".format(project_id), data=data)
         status_code = response.status_code
         json = response.json

--- a/plugins/modules/digital_ocean_block_storage.py
+++ b/plugins/modules/digital_ocean_block_storage.py
@@ -181,7 +181,9 @@ class DOBlockStorage(object):
     def __init__(self, module):
         self.module = module
         self.rest = DigitalOceanHelper(module)
-        self.projects = DigitalOceanProjects(module, self.rest)
+        if self.module.params.get("project"):
+            # only load for non-default project assignments
+            self.projects = DigitalOceanProjects(module, self.rest)
 
     def get_key_or_fail(self, k):
         v = self.module.params[k]

--- a/plugins/modules/digital_ocean_block_storage.py
+++ b/plugins/modules/digital_ocean_block_storage.py
@@ -169,7 +169,8 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.digitalocean.plugins.module_utils.digital_ocean import (
-    DigitalOceanHelper, DigitalOceanProjects
+    DigitalOceanHelper,
+    DigitalOceanProjects,
 )
 
 
@@ -292,10 +293,22 @@ class DOBlockStorage(object):
         json = response.json
         if status == 201:
             project_name = self.module.params.get("project")
-            if project_name:  # empty string is the default project, skip project assignment
+            if (
+                project_name
+            ):  # empty string is the default project, skip project assignment
                 urn = "do:volume:{0}".format(json["volume"]["id"])
-                assign_status, error_message, resources = self.projects.assign_to_project(project_name, urn)
-                self.module.exit_json(changed=True, id=json["volume"]["id"], msg=error_message, assign_status=assign_status, resources=resources)
+                (
+                    assign_status,
+                    error_message,
+                    resources,
+                ) = self.projects.assign_to_project(project_name, urn)
+                self.module.exit_json(
+                    changed=True,
+                    id=json["volume"]["id"],
+                    msg=error_message,
+                    assign_status=assign_status,
+                    resources=resources,
+                )
             else:
                 self.module.exit_json(changed=True, id=json["volume"]["id"])
         elif status == 409 and json["id"] == "conflict":

--- a/plugins/modules/digital_ocean_database.py
+++ b/plugins/modules/digital_ocean_database.py
@@ -147,7 +147,7 @@ data:
          ssl: true
          uri: rediss://default:REDACTED@testdatabase1-do-user-3097135-0.b.db.ondigitalocean.com:25061
          user: default
-      created_at: 2021-04-21T15:41:14Z
+      created_at: "2021-04-21T15:41:14Z"
       db_names: null
       engine: redis
       id: 37de10e4-808b-4f4b-b25f-7b5b3fd194ac

--- a/plugins/modules/digital_ocean_database.py
+++ b/plugins/modules/digital_ocean_database.py
@@ -200,7 +200,8 @@ import json
 import time
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible_collections.community.digitalocean.plugins.module_utils.digital_ocean import (
-    DigitalOceanHelper, DigitalOceanProjects
+    DigitalOceanHelper,
+    DigitalOceanProjects,
 )
 
 
@@ -333,13 +334,21 @@ class DODatabase(object):
             )
 
         if self.wait:
-           json_data = self.ensure_online(database_id)
+            json_data = self.ensure_online(database_id)
 
         project_name = self.module.params.get("project")
         if project_name:  # empty string is the default project, skip project assignment
             urn = "do:dbaas:{0}".format(database_id)
-            assign_status, error_message, resources = self.projects.assign_to_project(project_name, urn)
-            self.module.exit_json(changed=True, data=json_data, msg=error_message, assign_status=assign_status, resources=resources)
+            assign_status, error_message, resources = self.projects.assign_to_project(
+                project_name, urn
+            )
+            self.module.exit_json(
+                changed=True,
+                data=json_data,
+                msg=error_message,
+                assign_status=assign_status,
+                resources=resources,
+            )
         else:
             self.module.exit_json(changed=True, data=json_data)
 
@@ -418,7 +427,9 @@ def main():
             timeout=dict(type="int", default=30),
             wait=dict(type="bool", default=True),
             wait_timeout=dict(default=600, type="int"),
-            project_name=dict(type="str", aliases=["project"], required=False, default=""),
+            project_name=dict(
+                type="str", aliases=["project"], required=False, default=""
+            ),
         ),
         required_one_of=(["id", "name"],),
         required_if=(

--- a/plugins/modules/digital_ocean_database.py
+++ b/plugins/modules/digital_ocean_database.py
@@ -96,7 +96,7 @@ options:
     description:
     - Project to assign the resource to (project name, not UUID).
     - Defaults to the default project of the account (empty string).
-    - Currently only supported when C(command=create).
+    - Currently only supported when creating databases.
     type: str
     required: false
     default: ""

--- a/plugins/modules/digital_ocean_database.py
+++ b/plugins/modules/digital_ocean_database.py
@@ -116,6 +116,18 @@ EXAMPLES = r"""
     region: nyc1
     num_nodes: 1
   register: my_database
+
+- name: Create a Redis database (and assign to Project "test")
+  community.digitalocean.digital_ocean_database:
+    oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_KEY') }}"
+    state: present
+    name: testdatabase1
+    engine: redis
+    size: db-s-1vcpu-1gb
+    region: nyc1
+    num_nodes: 1
+    project_name: test
+  register: my_database
 """
 
 
@@ -124,48 +136,63 @@ data:
   description: A DigitalOcean database
   returned: success
   type: dict
-  sample: {
-    "database": {
-      "connection": {
-         "database": "",
-         "host": "testdatabase1-do-user-3097135-0.b.db.ondigitalocean.com",
-         "password": "REDACTED",
-         "port": 25061,
-         "protocol": "rediss",
-         "ssl": true,
-         "uri": "rediss://default:REDACTED@testdatabase1-do-user-3097135-0.b.db.ondigitalocean.com:25061",
-         "user": "default"
-      },
-      "created_at": "2021-04-21T15:41:14Z",
-      "db_names": null,
-      "engine": "redis",
-      "id": "37de10e4-808b-4f4b-b25f-7b5b3fd194ac",
-      "maintenance_window": {
-         "day": "monday",
-         "hour": "11:33:47",
-         "pending": false
-      },
-      "name": "testdatabase1",
-      "num_nodes": 1,
-      "private_connection": {
-         "database": "",
-         "host": "private-testdatabase1-do-user-3097135-0.b.db.ondigitalocean.com",
-         "password": "REDIS",
-         "port": 25061,
-         "protocol": "rediss",
-         "ssl": true,
-         "uri": "rediss://default:REDACTED@private-testdatabase1-do-user-3097135-0.b.db.ondigitalocean.com:25061",
-         "user": "default"
-      },
-      "private_network_uuid": "0db3519b-9efc-414a-8868-8f2e6934688c",
-      "region": "nyc1",
-      "size": "db-s-1vcpu-1gb",
-      "status": "online",
-      "tags": null,
-      "users": null,
-      "version": "6"
-    }
-  }
+  sample:
+    database:
+      connection:
+         database: ""
+         host: testdatabase1-do-user-3097135-0.b.db.ondigitalocean.com
+         password: REDACTED
+         port: 25061
+         protocol: rediss
+         ssl: true
+         uri: rediss://default:REDACTED@testdatabase1-do-user-3097135-0.b.db.ondigitalocean.com:25061
+         user: default
+      created_at: 2021-04-21T15:41:14Z
+      db_names: null
+      engine: redis
+      id: 37de10e4-808b-4f4b-b25f-7b5b3fd194ac
+      maintenance_window:
+         day: monday
+         hour: 11:33:47
+         pending: false
+      name: testdatabase1
+      num_nodes: 1
+      private_connection:
+         database: ""
+         host: private-testdatabase1-do-user-3097135-0.b.db.ondigitalocean.com
+         password: REDIS
+         port: 25061
+         protocol: rediss
+         ssl: true
+         uri: rediss://default:REDACTED@private-testdatabase1-do-user-3097135-0.b.db.ondigitalocean.com:25061
+         user: default
+      private_network_uuid: 0db3519b-9efc-414a-8868-8f2e6934688c,
+      region: nyc1
+      size: db-s-1vcpu-1gb
+      status: online
+      tags: null
+      users: null
+      version: 6
+msg:
+    description: Informational or error message encountered during execution
+    returned: changed
+    type: str
+    sample: No project named test2 found
+assign_status:
+    description: Assignment status (ok, not_found, assigned, already_assigned, service_down)
+    returned: changed
+    type: str
+    sample: assigned
+resources:
+    description: Resource assignment involved in project assignment
+    returned: changed
+    type: dict
+    sample:
+        assigned_at: '2021-10-25T17:39:38Z'
+        links:
+            self: https://api.digitalocean.com/v2/databases/126355fa-b147-40a6-850a-c44f5d2ad418
+        status: assigned
+        urn: do:dbaas:126355fa-b147-40a6-850a-c44f5d2ad418
 """
 
 

--- a/plugins/modules/digital_ocean_domain.py
+++ b/plugins/modules/digital_ocean_domain.py
@@ -41,7 +41,7 @@ options:
     description:
     - Project to assign the resource to (project name, not UUID).
     - Defaults to the default project of the account (empty string).
-    - Currently only supported when C(command=create).
+    - Currently only supported when creating domains.
     type: str
     required: false
     default: ""

--- a/plugins/modules/digital_ocean_domain.py
+++ b/plugins/modules/digital_ocean_domain.py
@@ -92,7 +92,8 @@ EXAMPLES = r"""
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.digitalocean.plugins.module_utils.digital_ocean import (
-    DigitalOceanHelper, DigitalOceanProjects
+    DigitalOceanHelper,
+    DigitalOceanProjects,
 )
 import time
 
@@ -205,15 +206,39 @@ def run(module):
                     if record is not None and "domain" in record:
                         domain = record.get("domain", None)
                         if domain is not None and "zone_file" in domain:
-                            if project_name:  # empty string is the default project, skip project assignment
-                                assign_status, error_message, resources = projects.assign_to_project(project_name, urn)
-                                module.exit_json(changed=True, domain=domain, msg=error_message, assign_status=assign_status, resources=resources)
+                            if (
+                                project_name
+                            ):  # empty string is the default project, skip project assignment
+                                (
+                                    assign_status,
+                                    error_message,
+                                    resources,
+                                ) = projects.assign_to_project(project_name, urn)
+                                module.exit_json(
+                                    changed=True,
+                                    domain=domain,
+                                    msg=error_message,
+                                    assign_status=assign_status,
+                                    resources=resources,
+                                )
                             else:
                                 module.exit_json(changed=True, domain=domain)
                     time.sleep(ZONE_FILE_SLEEP)
-                if project_name:  # empty string is the default project, skip project assignment
-                    assign_status, error_message, resources = projects.assign_to_project(project_name, urn)
-                    module.exit_json(changed=True, domain=domain, msg=error_message, assign_status=assign_status, resources=resources)
+                if (
+                    project_name
+                ):  # empty string is the default project, skip project assignment
+                    (
+                        assign_status,
+                        error_message,
+                        resources,
+                    ) = projects.assign_to_project(project_name, urn)
+                    module.exit_json(
+                        changed=True,
+                        domain=domain,
+                        msg=error_message,
+                        assign_status=assign_status,
+                        resources=resources,
+                    )
                 else:
                     module.exit_json(changed=True, domain=domain)
         else:

--- a/plugins/modules/digital_ocean_domain.py
+++ b/plugins/modules/digital_ocean_domain.py
@@ -36,6 +36,15 @@ options:
     description:
     - An 'A' record for '@' ($ORIGIN) will be created with the value 'ip'.  'ip' is an IP version 4 address.
     type: str
+  project_name:
+    aliases: ["project"]
+    description:
+    - Project to assign the resource to (project name, not UUID).
+    - Defaults to the default project of the account (empty string).
+    - Currently only supported when C(command=create).
+    type: str
+    required: false
+    default: ""
 extends_documentation_fragment:
 - community.digitalocean.digital_ocean.documentation
 
@@ -55,6 +64,13 @@ EXAMPLES = r"""
     state: present
     name: my.digitalocean.domain
     ip: 127.0.0.1
+
+- name: Create a domain (and associate to Project "test")
+  community.digitalocean.digital_ocean_domain:
+    state: present
+    name: my.digitalocean.domain
+    ip: 127.0.0.1
+    project: test
 
 # Create a droplet and corresponding domain
 - name: Create a droplet
@@ -76,7 +92,7 @@ EXAMPLES = r"""
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.digitalocean.plugins.module_utils.digital_ocean import (
-    DigitalOceanHelper,
+    DigitalOceanHelper, DigitalOceanProjects
 )
 import time
 
@@ -159,6 +175,10 @@ def run(module):
     do_manager = DoManager(module)
     state = module.params.get("state")
 
+    if module.params.get("project"):
+        # only load for non-default project assignments
+        projects = DigitalOceanProjects(module, do_manager)
+
     domain = do_manager.find()
     if state == "present":
         if not domain:
@@ -175,14 +195,27 @@ def run(module):
                 #
                 # Arguably, it's nice to see the records versus null, so, we'll just try a
                 # few times before giving up and returning null.
+
+                domain_name = module.params.get("name")
+                project_name = module.params.get("project")
+                urn = "do:domain:{0}".format(domain_name)
+
                 for i in range(ZONE_FILE_ATTEMPTS):
                     record = do_manager.domain_record()
                     if record is not None and "domain" in record:
-                        domain = record["domain"]
+                        domain = record.get("domain", None)
                         if domain is not None and "zone_file" in domain:
-                            module.exit_json(changed=True, domain=domain)
+                            if project_name:  # empty string is the default project, skip project assignment
+                                assign_status, error_message, resources = projects.assign_to_project(project_name, urn)
+                                module.exit_json(changed=True, domain=domain, msg=error_message, assign_status=assign_status, resources=resources)
+                            else:
+                                module.exit_json(changed=True, domain=domain)
                     time.sleep(ZONE_FILE_SLEEP)
-                module.exit_json(changed=True, domain=domain)
+                if project_name:  # empty string is the default project, skip project assignment
+                    assign_status, error_message, resources = projects.assign_to_project(project_name, urn)
+                    module.exit_json(changed=True, domain=domain, msg=error_message, assign_status=assign_status, resources=resources)
+                else:
+                    module.exit_json(changed=True, domain=domain)
         else:
             records = do_manager.all_domain_records()
             if module.params.get("ip"):
@@ -219,6 +252,7 @@ def main():
         name=dict(type="str"),
         id=dict(aliases=["droplet_id"], type="int"),
         ip=dict(type="str"),
+        project_name=dict(type="str", aliases=["project"], required=False, default=""),
     )
 
     module = AnsibleModule(

--- a/plugins/modules/digital_ocean_droplet.py
+++ b/plugins/modules/digital_ocean_droplet.py
@@ -252,9 +252,9 @@ resources:
     sample:
         assigned_at: '2021-10-25T17:39:38Z'
         links:
-            self: https://api.digitalocean.com/v2/volumes/8691c49e-35ba-11ec-9406-0a58ac1472b9
+            self: https://api.digitalocean.com/v2/droplets/3164494
         status: assigned
-        urn: do:volume:8691c49e-35ba-11ec-9406-0a58ac1472b9
+        urn: do:droplet:3164494
 """
 
 import time

--- a/plugins/modules/digital_ocean_droplet.py
+++ b/plugins/modules/digital_ocean_droplet.py
@@ -260,7 +260,8 @@ resources:
 import time
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible_collections.community.digitalocean.plugins.module_utils.digital_ocean import (
-    DigitalOceanHelper, DigitalOceanProjects
+    DigitalOceanHelper,
+    DigitalOceanProjects,
 )
 
 
@@ -621,8 +622,16 @@ class DODroplet(object):
         project_name = self.module.params.get("project")
         if project_name:  # empty string is the default project, skip project assignment
             urn = "do:droplet:{0}".format(droplet_id)
-            assign_status, error_message, resources = self.projects.assign_to_project(project_name, urn)
-            self.module.exit_json(changed=True, data={"droplet": droplet}, msg=error_message, assign_status=assign_status, resources=resources)
+            assign_status, error_message, resources = self.projects.assign_to_project(
+                project_name, urn
+            )
+            self.module.exit_json(
+                changed=True,
+                data={"droplet": droplet},
+                msg=error_message,
+                assign_status=assign_status,
+                resources=resources,
+            )
 
         self.module.exit_json(changed=True, data={"droplet": droplet})
 

--- a/plugins/modules/digital_ocean_droplet.py
+++ b/plugins/modules/digital_ocean_droplet.py
@@ -224,7 +224,7 @@ data:
                 id: 2233
                 name: Ubuntu 14.04 x64 vmlinuz-3.13.0-37-generic
                 version: 3.13.0-37-generic
-            created_at: 2014-11-14T16:36:31Z
+            created_at: "2014-11-14T16:36:31Z"
             features: ["virtio"]
             backup_ids: []
             snapshot_ids: []

--- a/plugins/modules/digital_ocean_floating_ip.py
+++ b/plugins/modules/digital_ocean_floating_ip.py
@@ -58,6 +58,15 @@ options:
       - This should only set to C(no) used on personally controlled sites using self-signed certificates.
     type: bool
     default: true
+  project_name:
+    aliases: ["project"]
+    description:
+    - Project to assign the resource to (project name, not UUID).
+    - Defaults to the default project of the account (empty string).
+    - Currently only supported when creating.
+    type: str
+    required: false
+    default: ""
 notes:
   - Version 2 of DigitalOcean API is used.
 requirements:
@@ -70,6 +79,12 @@ EXAMPLES = r"""
   community.digitalocean.digital_ocean_floating_ip:
     state: present
     region: lon1
+
+- name: Create a Floating IP in region lon1 (and assign to Project "test")
+  community.digitalocean.digital_ocean_floating_ip:
+    state: present
+    region: lon1
+    project: test
 
 - name: "Create a Floating IP assigned to Droplet ID 123456"
   community.digitalocean.digital_ocean_floating_ip:
@@ -101,40 +116,55 @@ data:
     description: a DigitalOcean Floating IP resource
     returned: success and no resource constraint
     type: dict
-    sample: {
-      "action": {
-        "id": 68212728,
-        "status": "in-progress",
-        "type": "assign_ip",
-        "started_at": "2015-10-15T17:45:44Z",
-        "completed_at": null,
-        "resource_id": 758603823,
-        "resource_type": "floating_ip",
-        "region": {
-          "name": "New York 3",
-          "slug": "nyc3",
-          "sizes": [
-            "512mb",
-            "1gb",
-            "2gb",
-            "4gb",
-            "8gb",
-            "16gb",
-            "32gb",
-            "48gb",
-            "64gb"
-          ],
-          "features": [
-            "private_networking",
-            "backups",
-            "ipv6",
-            "metadata"
-          ],
-          "available": true
-        },
-        "region_slug": "nyc3"
-      }
-    }
+    sample:
+      action:
+        id: 68212728
+        status: in-progress
+        type: assign_ip
+        started_at: '2015-10-15T17:45:44Z'
+        completed_at: null
+        resource_id: 758603823
+        resource_type: floating_ip
+        region:
+          name: New York 3
+          slug: nyc3
+          sizes:
+            - 512mb,
+            - 1gb,
+            - 2gb,
+            - 4gb,
+            - 8gb,
+            - 16gb,
+            - 32gb,
+            - 48gb,
+            - 64gb
+          features:
+            - private_networking
+            - backups
+            - ipv6
+            - metadata
+          available: true
+        region_slug: nyc3
+msg:
+    description: Informational or error message encountered during execution
+    returned: changed
+    type: str
+    sample: No project named test2 found
+assign_status:
+    description: Assignment status (ok, not_found, assigned, already_assigned, service_down)
+    returned: changed
+    type: str
+    sample: assigned
+resources:
+    description: Resource assignment involved in project assignment
+    returned: changed
+    type: dict
+    sample:
+        assigned_at: '2021-10-25T17:39:38Z'
+        links:
+            self: https://api.digitalocean.com/v2/floating_ips/157.230.64.107
+        status: assigned
+        urn: do:floatingip:157.230.64.107
 """
 
 import json
@@ -143,6 +173,11 @@ import time
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.urls import fetch_url
+
+from ansible_collections.community.digitalocean.plugins.module_utils.digital_ocean import (
+    DigitalOceanHelper,
+    DigitalOceanProjects,
+)
 
 
 class Response(object):
@@ -399,7 +434,43 @@ def create_floating_ips(module, rest):
     status_code = response.status_code
     json_data = response.json
     if status_code == 202:
-        module.exit_json(changed=True, data=json_data)
+        if module.params.get(
+            "project"
+        ):  # only load for non-default project assignments
+            rest = DigitalOceanHelper(module)
+            projects = DigitalOceanProjects(module, rest)
+            project_name = module.params.get("project")
+            if (
+                project_name
+            ):  # empty string is the default project, skip project assignment
+                floating_ip = json_data.get("floating_ip")
+                ip = floating_ip.get("ip")
+                if ip:
+                    urn = "do:floatingip:{0}".format(ip)
+                    (
+                        assign_status,
+                        error_message,
+                        resources,
+                    ) = projects.assign_to_project(project_name, urn)
+                    module.exit_json(
+                        changed=True,
+                        data=json_data,
+                        msg=error_message,
+                        assign_status=assign_status,
+                        resources=resources,
+                    )
+                else:
+                    module.exit_json(
+                        changed=True,
+                        msg="Floating IP created but not assigned to the {0} Project (missing information from the API response)".format(
+                            ip
+                        ),
+                        data=json_data,
+                    )
+            else:
+                module.exit_json(changed=True, data=json_data)
+        else:
+            module.exit_json(changed=True, data=json_data)
     else:
         module.fail_json(
             msg="Error creating floating ip [{0}: {1}]".format(
@@ -429,6 +500,9 @@ def main():
             ),
             validate_certs=dict(type="bool", default=True),
             timeout=dict(type="int", default=30),
+            project_name=dict(
+                type="str", aliases=["project"], required=False, default=""
+            ),
         ),
         required_if=[
             ("state", "delete", ["ip"]),

--- a/plugins/modules/digital_ocean_floating_ip.py
+++ b/plugins/modules/digital_ocean_floating_ip.py
@@ -463,7 +463,7 @@ def create_floating_ips(module, rest):
                     module.exit_json(
                         changed=True,
                         msg="Floating IP created but not assigned to the {0} Project (missing information from the API response)".format(
-                            ip
+                            project_name
                         ),
                         data=json_data,
                     )

--- a/plugins/modules/digital_ocean_load_balancer.py
+++ b/plugins/modules/digital_ocean_load_balancer.py
@@ -394,7 +394,8 @@ import time
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible_collections.community.digitalocean.plugins.module_utils.digital_ocean import (
-    DigitalOceanHelper, DigitalOceanProjects
+    DigitalOceanHelper,
+    DigitalOceanProjects,
 )
 
 
@@ -618,9 +619,7 @@ class DOLoadBalancer(object):
             self.ensure_active()
 
         project_name = self.module.params.get("project")
-        if (
-            project_name
-        ):  # empty string is the default project, skip project assignment
+        if project_name:  # empty string is the default project, skip project assignment
             urn = "do:loadbalancer:{0}".format(self.id)
             (
                 assign_status,
@@ -758,7 +757,9 @@ def main():
             vpc_uuid=dict(type="str", required=False),
             wait=dict(type="bool", default=True),
             wait_timeout=dict(type="int", default=600),
-            project_name=dict(type="str", aliases=["project"], required=False, default=""),
+            project_name=dict(
+                type="str", aliases=["project"], required=False, default=""
+            ),
         ),
         required_if=(
             [

--- a/plugins/modules/digital_ocean_load_balancer.py
+++ b/plugins/modules/digital_ocean_load_balancer.py
@@ -203,6 +203,15 @@ options:
       - How long before wait gives up, in seconds, when creating a Load Balancer.
     type: int
     default: 600
+  project_name:
+    aliases: ["project"]
+    description:
+    - Project to assign the resource to (project name, not UUID).
+    - Defaults to the default project of the account (empty string).
+    - Currently only supported when creating.
+    type: str
+    required: false
+    default: ""
 """
 
 
@@ -221,6 +230,22 @@ EXAMPLES = r"""
         target_port: 8080
         certificate_id: ""
         tls_passthrough: false
+
+- name: Create a Load Balancer (and assign to Project "test")
+  community.digitalocean.digital_ocean_load_balancer:
+    state: present
+    name: test-loadbalancer-1
+    droplet_ids:
+      - 12345678
+    region: nyc1
+    forwarding_rules:
+      - entry_protocol: http
+        entry_port: 8080
+        target_protocol: http
+        target_port: 8080
+        certificate_id: ""
+        tls_passthrough: false
+    project: test
 """
 
 
@@ -342,6 +367,26 @@ data:
         type: none
       tag: ''
       vpc_uuid: b8fd9a58-d93d-4329-b54a-78a397d64855
+msg:
+    description: Informational or error message encountered during execution
+    returned: changed
+    type: str
+    sample: No project named test2 found
+assign_status:
+    description: Assignment status (ok, not_found, assigned, already_assigned, service_down)
+    returned: changed
+    type: str
+    sample: assigned
+resources:
+    description: Resource assignment involved in project assignment
+    returned: changed
+    type: dict
+    sample:
+        assigned_at: '2021-10-25T17:39:38Z'
+        links:
+            self: https://api.digitalocean.com/v2/load_balancers/17d171d0-8a8b-4251-9c18-c96cc515d36d
+        status: assigned
+        urn: do:loadbalancer:17d171d0-8a8b-4251-9c18-c96cc515d36d
 """
 
 
@@ -349,7 +394,7 @@ import time
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible_collections.community.digitalocean.plugins.module_utils.digital_ocean import (
-    DigitalOceanHelper,
+    DigitalOceanHelper, DigitalOceanProjects
 )
 
 
@@ -365,6 +410,9 @@ class DOLoadBalancer(object):
         self.module.params.pop("oauth_token")
         self.wait = self.module.params.pop("wait", True)
         self.wait_timeout = self.module.params.pop("wait_timeout", 600)
+        if self.module.params.get("project"):
+            # only load for non-default project assignments
+            self.projects = DigitalOceanProjects(module, self.rest)
 
     def get_by_id(self):
         """Fetch an existing DigitalOcean Load Balancer (by id)
@@ -569,7 +617,25 @@ class DOLoadBalancer(object):
         if self.wait:
             self.ensure_active()
 
-        self.module.exit_json(changed=True, data=json_data)
+        project_name = self.module.params.get("project")
+        if (
+            project_name
+        ):  # empty string is the default project, skip project assignment
+            urn = "do:loadbalancer:{0}".format(self.id)
+            (
+                assign_status,
+                error_message,
+                resources,
+            ) = self.projects.assign_to_project(project_name, urn)
+            self.module.exit_json(
+                changed=True,
+                data=json_data,
+                msg=error_message,
+                assign_status=assign_status,
+                resources=resources,
+            )
+        else:
+            self.module.exit_json(changed=True, data=json_data)
 
     def delete(self):
         """Deletes a DigitalOcean Load Balancer
@@ -692,6 +758,7 @@ def main():
             vpc_uuid=dict(type="str", required=False),
             wait=dict(type="bool", default=True),
             wait_timeout=dict(type="int", default=600),
+            project_name=dict(type="str", aliases=["project"], required=False, default=""),
         ),
         required_if=(
             [

--- a/tests/integration/targets/digital_ocean_block_storage/defaults/main.yml
+++ b/tests/integration/targets/digital_ocean_block_storage/defaults/main.yml
@@ -4,3 +4,4 @@ volume_size: 15
 volume_down_size: 10
 volume_up_size: 20
 timeout: 900
+project_name: gh-ci-project

--- a/tests/integration/targets/digital_ocean_block_storage/tasks/main.yml
+++ b/tests/integration/targets/digital_ocean_block_storage/tasks/main.yml
@@ -84,6 +84,43 @@
         that:
           - result.changed
 
+    - name: Remove the volume
+      community.digitalocean.digital_ocean_block_storage:
+        oauth_token: "{{ do_api_key }}"
+        command: create
+        state: absent
+        volume_name: "{{ volume_name }}"
+        region: "{{ do_region }}"
+      register: result
+
+    - name: Verify the volume is deleted
+      ansible.builtin.assert:
+        that:
+          - result.changed
+
+    - name: Create a volume (and associate with Project)
+      community.digitalocean.digital_ocean_block_storage:
+        oauth_token: "{{ do_api_key }}"
+        command: create
+        state: present
+        volume_name: "{{ volume_name }}"
+        region: "{{ do_region }}"
+        block_size: "{{ volume_size }}"
+        project: "{{ project_name }}"
+      register: result
+
+    - name: Verify volume is present
+      ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.assign_status is defined
+          - result.assign_status == "assigned"
+          - result.msg is defined
+          - "'Assigned do:volume' in result.msg"
+          - result.resources is defined
+          - result.resources.status is defined
+          - result.resources.status == "assigned"
+
   always:
 
     - name: Remove the volume

--- a/tests/integration/targets/digital_ocean_database/defaults/main.yml
+++ b/tests/integration/targets/digital_ocean_database/defaults/main.yml
@@ -4,3 +4,4 @@ database_engine: redis
 database_size: db-s-1vcpu-1gb
 database_num_nodes: 1
 database_wait_timeout: 900
+project_name: gh-ci-project

--- a/tests/integration/targets/digital_ocean_database/tasks/main.yml
+++ b/tests/integration/targets/digital_ocean_database/tasks/main.yml
@@ -100,6 +100,49 @@
       ansible.builtin.pause:
         minutes: 1
 
+    - name: Delete the database
+      community.digitalocean.digital_ocean_database:
+        oauth_token: "{{ do_api_key }}"
+        state: absent
+        name: "{{ database_name }}"
+        region: "{{ do_region }}"
+        engine: "{{ database_engine }}"
+        size: "{{ database_size }}"
+      register: result
+
+    - name: Verify the database is deleted
+      ansible.builtin.assert:
+        that:
+          - result.changed
+
+    - name: Create the database (and associate with Project)
+      community.digitalocean.digital_ocean_database:
+        oauth_token: "{{ do_api_key }}"
+        state: present
+        name: "{{ database_name }}"
+        region: "{{ do_region }}"
+        engine: "{{ database_engine }}"
+        size: "{{ database_size }}"
+        wait_timeout: "{{ database_wait_timeout }}"
+        project: "{{ project_name }}"
+      register: result
+
+    - name: Verify database is present
+      ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.data is defined
+          - result.data.database is defined
+          - result.data.database.name is defined
+          - result.data.database.name == database_name
+          - result.assign_status is defined
+          - result.assign_status == "assigned"
+          - result.msg is defined
+          - "'Assigned do:dbaas' in result.msg"
+          - result.resources is defined
+          - result.resources.status is defined
+          - result.resources.status == "assigned"
+
   always:
 
     - name: Delete the database

--- a/tests/integration/targets/digital_ocean_domain/defaults/main.yml
+++ b/tests/integration/targets/digital_ocean_domain/defaults/main.yml
@@ -1,1 +1,2 @@
 domain_name: 0bb54d769d27ae8b4d16c8abddb7c03b767b4fa2.com
+project_name: gh-ci-project

--- a/tests/integration/targets/digital_ocean_domain/tasks/main.yml
+++ b/tests/integration/targets/digital_ocean_domain/tasks/main.yml
@@ -55,6 +55,42 @@
           - result.result.name == "www"
           - result.result.data == "127.0.0.1"
 
+    - name: Delete the domain
+      community.digitalocean.digital_ocean_domain:
+        oauth_token: "{{ do_api_key }}"
+        state: absent
+        name: "{{ domain_name }}"
+      register: result
+
+    - name: Ensure domain was deleted
+      ansible.builtin.assert:
+        that:
+          - result.changed
+
+    - name: Create the domain (and assign to Project)
+      community.digitalocean.digital_ocean_domain:
+        oauth_token: "{{ do_api_key }}"
+        state: present
+        name: "{{ domain_name }}"
+        ip: 127.0.0.1
+        project: "{{ project_name }}"
+      register: result
+
+    - name: Ensure domain was created
+      ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.domain is defined
+          - result.domain.name is defined
+          - result.domain.name == domain_name
+          - result.assign_status is defined
+          - result.assign_status == "assigned"
+          - result.msg is defined
+          - "'Assigned do:domain' in result.msg"
+          - result.resources is defined
+          - result.resources.status is defined
+          - result.resources.status == "assigned"
+
   always:
 
     - name: Delete the domain

--- a/tests/integration/targets/digital_ocean_droplet/defaults/main.yml
+++ b/tests/integration/targets/digital_ocean_droplet/defaults/main.yml
@@ -3,3 +3,4 @@ droplet_name: gh-ci-droplet
 droplet_image: ubuntu-18-04-x64
 droplet_size: s-1vcpu-1gb
 droplet_new_size: s-1vcpu-2gb
+project_name: gh-ci-project

--- a/tests/integration/targets/digital_ocean_droplet/tasks/main.yml
+++ b/tests/integration/targets/digital_ocean_droplet/tasks/main.yml
@@ -190,6 +190,40 @@
       ansible.builtin.pause:
         minutes: 1
 
+    - name: Create the Droplet (and assign to Project)
+      community.digitalocean.digital_ocean_droplet:
+        oauth_token: "{{ do_api_key }}"
+        state: active
+        name: "{{ droplet_name }}"
+        unique_name: true
+        region: "{{ do_region }}"
+        image: "{{ droplet_image }}"
+        size: "{{ droplet_size }}"
+        wait_timeout: 500
+        project: "{{ project_name }}"
+      register: result
+
+    - name: Give the cloud a minute to settle
+      ansible.builtin.pause:
+        minutes: 1
+
+    - name: Verify Droplet is present (from active)
+      ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.data is defined
+          - result.data.droplet is defined
+          - result.data.droplet.name is defined
+          - result.data.droplet.name == droplet_name
+          - result.data.droplet.status in ["new", "active", "available"]
+          - result.assign_status is defined
+          - result.assign_status == "assigned"
+          - result.msg is defined
+          - "'Assigned do:droplet' in result.msg"
+          - result.resources is defined
+          - result.resources.status is defined
+          - result.resources.status == "assigned"
+
   always:
 
     - name: Delete the Droplet (always)

--- a/tests/integration/targets/digital_ocean_droplet/tasks/main.yml
+++ b/tests/integration/targets/digital_ocean_droplet/tasks/main.yml
@@ -190,6 +190,19 @@
       ansible.builtin.pause:
         minutes: 1
 
+    - name: Delete the Droplet (always)
+      community.digitalocean.digital_ocean_droplet:
+        oauth_token: "{{ do_api_key }}"
+        state: absent
+        name: "{{ droplet_name }}"
+        unique_name: true
+        region: "{{ do_region }}"
+      ignore_errors: true  # Should this fail, we'll clean it up next run
+
+    - name: Give the cloud a minute to settle
+      ansible.builtin.pause:
+        minutes: 1
+
     - name: Create the Droplet (and assign to Project)
       community.digitalocean.digital_ocean_droplet:
         oauth_token: "{{ do_api_key }}"

--- a/tests/integration/targets/digital_ocean_floating_ip/defaults/main.yml
+++ b/tests/integration/targets/digital_ocean_floating_ip/defaults/main.yml
@@ -2,3 +2,4 @@ do_region: nyc1
 droplet_name: gh-ci-droplet
 droplet_image: ubuntu-18-04-x64
 droplet_size: s-1vcpu-1gb
+project_name: gh-ci-project

--- a/tests/integration/targets/digital_ocean_floating_ip/tasks/main.yml
+++ b/tests/integration/targets/digital_ocean_floating_ip/tasks/main.yml
@@ -26,10 +26,10 @@
         oauth_token: "{{ do_api_key }}"
       loop: "{{ result.floating_ips }}"
 
-    - name: Create the testing Droplet (present)
+    - name: Create the testing Droplet (active)
       community.digitalocean.digital_ocean_droplet:
         oauth_token: "{{ do_api_key }}"
-        state: present
+        state: active
         name: "{{ droplet_name }}"
         unique_name: true
         region: "{{ do_region }}"
@@ -38,11 +38,7 @@
         wait_timeout: 500
       register: droplet_result
 
-    - name: Give the cloud a minute to settle
-      ansible.builtin.pause:
-        minutes: 1
-
-    - name: Verify Droplet is present (from present)
+    - name: Verify Droplet is active
       ansible.builtin.assert:
         that:
           - droplet_result.changed
@@ -50,7 +46,52 @@
           - droplet_result.data.droplet is defined
           - droplet_result.data.droplet.name is defined
           - droplet_result.data.droplet.name == droplet_name
-          - droplet_result.data.droplet.status in ["new", "active", "available"]
+          - droplet_result.data.droplet.status == "active"
+
+    - name: Create a Floating IP and assign to Project
+      community.digitalocean.digital_ocean_floating_ip:
+        state: present
+        region: "{{ do_region }}"
+        oauth_token: "{{ do_api_key }}"
+        project: "{{ project_name }}"
+      register: floating_ip
+
+    - name: Verify that a Floating IP was created (and assigned to Project)
+      ansible.builtin.assert:
+        that:
+          - floating_ip.changed
+          - floating_ip.assign_status is defined
+          - floating_ip.assign_status == "assigned"
+          - floating_ip.msg is defined
+          - "'Assigned do:floatingip' in floating_ip.msg"
+          - floating_ip.resources is defined
+          - floating_ip.resources.status is defined
+          - floating_ip.resources.status == "assigned"
+
+    - name: Give the cloud a minute to settle
+      ansible.builtin.pause:
+        minutes: 1
+
+    - name: Delete the Floating IP
+      community.digitalocean.digital_ocean_floating_ip:
+        state: absent
+        ip: "{{ floating_ip.data.floating_ip.ip }}"
+        region: "{{ do_region }}"
+        oauth_token: "{{ do_api_key }}"
+      register: result
+      when:
+        - floating_ip.data.floating_ip.ip is defined
+
+    - name: Verify that a Floating IP was deleted
+      ansible.builtin.assert:
+        that:
+          - result.changed
+      when:
+        - floating_ip.data.floating_ip.ip is defined
+
+    - name: Give the cloud a minute to settle
+      ansible.builtin.pause:
+        minutes: 1
 
     - name: "Create a Floating IP"
       community.digitalocean.digital_ocean_floating_ip:

--- a/tests/integration/targets/digital_ocean_load_balancer/defaults/main.yml
+++ b/tests/integration/targets/digital_ocean_load_balancer/defaults/main.yml
@@ -4,3 +4,4 @@ droplet_image: ubuntu-18-04-x64
 droplet_size: s-1vcpu-1gb
 lb_name: gh-ci-loadbalancer
 lb_size: lb-small
+project_name: gh-ci-project

--- a/tests/integration/targets/digital_ocean_load_balancer/tasks/main.yml
+++ b/tests/integration/targets/digital_ocean_load_balancer/tasks/main.yml
@@ -88,6 +88,48 @@
           - lb.failed is false
           - "'updated: algorithm' in lb.msg"
 
+    - name: Delete the Load Balancer
+      community.digitalocean.digital_ocean_load_balancer:
+        oauth_token: "{{ do_api_key }}"
+        state: absent
+        name: "{{ lb_name }}"
+        region: "{{ do_region }}"
+      register: result
+
+    - name: Verify Load Balancer is deleted
+      ansible.builtin.assert:
+        that:
+          - result.changed
+
+    - name: Create the Load Balancer (and assign to Project)
+      community.digitalocean.digital_ocean_load_balancer:
+        oauth_token: "{{ do_api_key }}"
+        state: present
+        name: "{{ lb_name }}"
+        algorithm: round_robin
+        droplet_ids:
+          - "{{ droplet.data.droplet.id }}"
+        region: "{{ do_region }}"
+        project: "{{ project_name }}"
+      register: lb
+
+    - name: Verify Load Balancer is present (from present)
+      ansible.builtin.assert:
+        that:
+          - lb.changed
+          - lb.data is defined
+          - lb.data.load_balancer is defined
+          - lb.data.load_balancer.name is defined
+          - lb.data.load_balancer.name == lb_name
+          - lb.data.load_balancer.status in ["new", "active", "available"]
+          - lb.assign_status is defined
+          - lb.assign_status == "assigned"
+          - lb.msg is defined
+          - "'Assigned do:loadbalancer' in lb.msg"
+          - lb.resources is defined
+          - lb.resources.status is defined
+          - lb.resources.status == "assigned"
+
   always:
 
     - name: Delete the Droplet


### PR DESCRIPTION
Fixes #171.

Adds Project assignment support (at the time of creation) for the following modules:

* digital_ocean_block_storage
* digital_ocean_database
* digital_ocean_domain
* digital_ocean_droplet
* digital_ocean_floating_ip
* digital_ocean_load_balancer

That is, the ability to associate these resources to [Projects](https://docs.digitalocean.com/products/projects/) when they're created.

Trying to make the smallest possible change, so, if the project isn't specified, the behavior will be unchanged (i.e., the resources will land in the "default" Project as before).