### PR TITLE
Fix #159

### DIFF
--- a/changelogs/fragments/159-add-droplet-firewall.yaml
+++ b/changelogs/fragments/159-add-droplet-firewall.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - digital_ocean_droplet - adding ability to apply and remove firewall by using droplet module (https://github.com/ansible-collections/community.digitalocean/issues/159).
+  - digital_ocean_droplet - require unique_name for state=absent to avoid unintentional droplet deletions.

--- a/plugins/modules/digital_ocean_droplet.py
+++ b/plugins/modules/digital_ocean_droplet.py
@@ -68,6 +68,13 @@ options:
     required: false
     type: list
     elements: str
+  firewall:
+    description:
+      - Array of firewall names to apply to the droplet.
+      - Omitting a firewall name that is currently applied to a droplet will remove it.
+    required: false
+    type: list
+    elements: str
   private_networking:
     description:
       - Add an additional, private network interface to the Droplet (for inter-Droplet communication).
@@ -157,7 +164,7 @@ EXAMPLES = r"""
     oauth_token: XXX
     size: 2gb
     region: sfo1
-    image: ubuntu-16-04-x64
+    image: ubuntu-18-04-x64
     wait_timeout: 500
     ssh_keys: [ .... ]
   register: my_droplet
@@ -186,7 +193,19 @@ EXAMPLES = r"""
     oauth_token: XXX
     size: 2gb
     region: sfo1
-    image: ubuntu-16-04-x64
+    image: ubuntu-18-04-x64
+    wait_timeout: 500
+
+- name: Ensure a droplet is present and has firewall rules applied
+  community.digitalocean.digital_ocean_droplet:
+    state: present
+    id: 123
+    name: mydroplet
+    oauth_token: XXX
+    size: 2gb
+    region: sfo1
+    image: ubuntu-18-04-x64
+    firewall: ['myfirewall', 'anotherfirewall']
     wait_timeout: 500
 
 - name: Ensure a droplet is present with SSH keys installed
@@ -198,7 +217,7 @@ EXAMPLES = r"""
     size: 2gb
     region: sfo1
     ssh_keys: ['1534404', '1784768']
-    image: ubuntu-16-04-x64
+    image: ubuntu-18-04-x64
     wait_timeout: 500
 """
 
@@ -290,6 +309,82 @@ class DODroplet(object):
         if self.module.params.get("project"):
             # only load for non-default project assignments
             self.projects = DigitalOceanProjects(module, self.rest)
+        self.firewalls = self.get_firewalls()
+
+    def get_firewalls(self):
+        response = self.rest.get("firewalls")
+        status_code = response.status_code
+        json_data = response.json
+        if status_code != 200:
+            self.module.fail_json(msg="Failed to get firewalls", data=json_data)
+
+        return self.rest.get_paginated_data(
+            base_url="firewalls?", data_key_name="firewalls"
+        )
+
+    def get_firewall_by_name(self):
+        rule = {}
+        item = 0
+        for firewall in self.firewalls:
+            for firewall_name in self.module.params["firewall"]:
+                if firewall_name in firewall["name"]:
+                    rule[item] = {}
+                    rule[item].update(firewall)
+                    item += 1
+        if len(rule) > 0:
+            return rule
+        return None
+
+    def add_droplet_to_firewalls(self):
+        rule = self.get_firewall_by_name()
+        if rule is None:
+            err = "Failed to find firewalls: {0}".format(self.module.params["firewall"])
+            return err
+        json_data = self.get_droplet()
+        if json_data is not None:
+            request_params = {}
+            droplet = json_data.get("droplet", None)
+            droplet_id = droplet.get("id", None)
+            request_params["droplet_ids"] = [droplet_id]
+            for firewall in rule:
+                if droplet_id not in rule[firewall]["droplet_ids"]:
+                    response = self.rest.post(
+                        "firewalls/{0}/droplets".format(rule[firewall]["id"]),
+                        data=request_params,
+                    )
+                    json_data = response.json
+                    status_code = response.status_code
+                    if status_code != 204:
+                        err = "Failed to add droplet {0} to firewall {1}".format(
+                            droplet_id, rule[firewall]["id"]
+                        )
+                        return err
+        return None
+
+    def remove_droplet_from_firewalls(self):
+        json_data = self.get_droplet()
+        if json_data is not None:
+            request_params = {}
+            droplet = json_data.get("droplet", None)
+            droplet_id = droplet.get("id", None)
+            request_params["droplet_ids"] = [droplet_id]
+            for firewall in self.firewalls:
+                if (
+                    firewall["name"] not in self.module.params["firewall"]
+                    and droplet_id in firewall["droplet_ids"]
+                ):
+                    response = self.rest.delete(
+                        "firewalls/{0}/droplets".format(firewall["id"]),
+                        data=request_params,
+                    )
+                    json_data = response.json
+                    status_code = response.status_code
+                    if status_code != 204:
+                        err = "Failed to add droplet {0} to firewall {1}".format(
+                            droplet_id, firewall["id"]
+                        )
+                        return err
+        return None
 
     def get_by_id(self, droplet_id):
         if not droplet_id:
@@ -532,7 +627,6 @@ class DODroplet(object):
 
     def create(self, state):
         json_data = self.get_droplet()
-
         # We have the Droplet
         if json_data is not None:
             droplet = json_data.get("droplet", None)
@@ -545,6 +639,28 @@ class DODroplet(object):
                     msg=DODroplet.failure_message["unexpected"].format(
                         "no Droplet ID or size"
                     ),
+                )
+
+            # Add droplet to a firewall if specified
+            if self.module.params["firewall"] is not None:
+                if len(self.module.params["firewall"]) > 0:
+                    firewall_add = self.add_droplet_to_firewalls()
+                    if firewall_add is not None:
+                        self.module.fail_json(
+                            changed=False,
+                            msg=firewall_add,
+                            data={"droplet": droplet, "firewall": firewall_add},
+                        )
+                firewall_remove = self.remove_droplet_from_firewalls()
+                if firewall_remove is not None:
+                    self.module.fail_json(
+                        changed=False,
+                        msg=firewall_remove,
+                        data={"droplet": droplet, "firewall": firewall_remove},
+                    )
+                self.module.exit_json(
+                    changed=True,
+                    data={"droplet": droplet},
                 )
 
             # Check mode
@@ -632,12 +748,33 @@ class DODroplet(object):
                 assign_status=assign_status,
                 resources=resources,
             )
+        # Add droplet to firewall if specified
+        if self.module.params["firewall"] is not None:
+            # raise Exception(self.module.params["firewall"])
+            firewall_add = self.add_droplet_to_firewalls()
+            if firewall_add is not None:
+                self.module.fail_json(
+                    changed=False,
+                    msg=firewall_add,
+                    data={"droplet": droplet, "firewall": firewall_add},
+                )
+            firewall_remove = self.remove_droplet_from_firewalls()
+            if firewall_remove is not None:
+                self.module.fail_json(
+                    changed=False,
+                    msg=firewall_remove,
+                    data={"droplet": droplet, "firewall": firewall_remove},
+                )
+            self.module.exit_json(changed=True, data={"droplet": droplet})
 
         self.module.exit_json(changed=True, data={"droplet": droplet})
 
     def delete(self):
+        if not self.unique_name:
+            self.module.fail_json(
+                changed=False, msg="unique_name must be set for deletes"
+            )
         json_data = self.get_droplet()
-
         if json_data is None:
             self.module.exit_json(changed=False, msg="Droplet not found")
 
@@ -709,6 +846,7 @@ def main():
         unique_name=dict(type="bool", default=False),
         resize_disk=dict(type="bool", default=False),
         project_name=dict(type="str", aliases=["project"], required=False, default=""),
+        firewall=dict(type="list", elements="str", default=None),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,
@@ -718,6 +856,7 @@ def main():
                 ("state", "present", ["name", "size", "image", "region"]),
                 ("state", "active", ["name", "size", "image", "region"]),
                 ("state", "inactive", ["name", "size", "image", "region"]),
+                ("state", "absent", ["name", "unique_name"]),
             ]
         ),
         supports_check_mode=True,

--- a/plugins/modules/digital_ocean_droplet.py
+++ b/plugins/modules/digital_ocean_droplet.py
@@ -70,7 +70,7 @@ options:
     elements: str
   firewall:
     description:
-      - Array of firewall names to apply to the droplet.
+      - Array of firewall names to apply to the Droplet.
       - Omitting a firewall name that is currently applied to a droplet will remove it.
     required: false
     type: list

--- a/tests/integration/targets/digital_ocean_droplet/defaults/main.yml
+++ b/tests/integration/targets/digital_ocean_droplet/defaults/main.yml
@@ -1,5 +1,6 @@
 do_region: nyc1
 droplet_name: gh-ci-droplet
+firewall_name: gh-ci-firewall
 droplet_image: ubuntu-18-04-x64
 droplet_size: s-1vcpu-1gb
 droplet_new_size: s-1vcpu-2gb

--- a/tests/integration/targets/digital_ocean_droplet/defaults/main.yml
+++ b/tests/integration/targets/digital_ocean_droplet/defaults/main.yml
@@ -1,7 +1,13 @@
 do_region: nyc1
 droplet_name: gh-ci-droplet
-firewall_name: gh-ci-firewall
 droplet_image: ubuntu-18-04-x64
 droplet_size: s-1vcpu-1gb
 droplet_new_size: s-1vcpu-2gb
 project_name: gh-ci-project
+firewall_name: gh-ci-firewall
+firewall_inbound_rules:
+  - protocol: "tcp"
+    ports: "9999"
+    sources:
+      addresses: ["0.0.0.0/0", "::/0"]
+firewall_outbound_rules: []

--- a/tests/integration/targets/digital_ocean_droplet/tasks/main.yml
+++ b/tests/integration/targets/digital_ocean_droplet/tasks/main.yml
@@ -236,8 +236,115 @@
           - result.resources is defined
           - result.resources.status is defined
           - result.resources.status == "assigned"
+    # Droplet plus firewall tests
+    - name: Create a test firewall
+      community.digitalocean.digital_ocean_firewall:
+        oauth_token: "{{ do_api_key }}"
+        name: "{{ firewall_name }}"
+        state: present
+        inbound_rules:
+          - protocol: "tcp"
+            ports: "80"
+            sources:
+              addresses: ["0.0.0.0/0", "::/0"]
+          - protocol: "tcp"
+            ports: "443"
+            sources:
+              addresses: ["0.0.0.0/0", "::/0"]
+        outbound_rules:
+          - protocol: "tcp"
+            ports: "1-65535"
+            destinations:
+              addresses: ["0.0.0.0/0", "::/0"]
+          - protocol: "udp"
+            ports: "1-65535"
+            destinations:
+              addresses: ["0.0.0.0/0", "::/0"]
+          - protocol: "icmp"
+            ports: "1-65535"
+            destinations:
+              addresses: ["0.0.0.0/0", "::/0"]
+        droplet_ids: []
+        tags: ["testing"]
+      register: testing_firewall
+
+    - name: Verify firewall was created
+      ansible.builtin.assert:
+        that:
+          - testing_firewall is defined
+          - testing_firewall.changed is true
+
+    - name: Create a new droplet and add to the above firewall
+      community.digitalocean.digital_ocean_droplet:
+        oauth_token: "{{ do_api_key }}"
+        state: present
+        name: "{{ droplet_name }}"
+        unique_name: true
+        firewall: ["{{ firewall_name }}"]
+        size: "{{ droplet_size }}"
+        region: "{{ do_region }}"
+        image: "{{ droplet_image }}"
+        wait_timeout: 500
+      register: firewall_droplet
+
+    - name: Verify the droplet has created and has firewall applied
+      ansible.builtin.assert:
+        that:
+          - firewall_droplet is defined
+          - firewall_droplet.changed is true
+
+    - name: Check our firewall for the new droplet
+      community.digitalocean.digital_ocean_firewall_info:
+        oauth_token: "{{ do_api_key }}"
+        name: "{{ firewall_name }}"
+      register: firewall_settings
+
+    - name: Verify details of firewall with droplet
+      ansible.builtin.assert:
+        that:
+          - firewall_settings is defined
+          - "{{ (firewall_settings.data | map(attribute='droplet_ids'))[0] | length > 0 }}"
+          - "{{ firewall_droplet.data.droplet.id }} in {{ (firewall_settings.data | map(attribute='droplet_ids'))[0] }}"
+
+    - name: Rerun on above droplet and remove firewall
+      community.digitalocean.digital_ocean_droplet:
+        oauth_token: "{{ do_api_key }}"
+        state: present
+        name: "{{ droplet_name }}"
+        unique_name: true
+        firewall: []
+        size: "{{ droplet_size }}"
+        region: "{{ do_region }}"
+        image: "{{ droplet_image }}"
+        wait_timeout: 500
+      register: firewall_droplet_removal
+
+    - name: Verify things were changed for firewall removal
+      ansible.builtin.assert:
+        that:
+          - firewall_droplet_removal is defined
+          - firewall_droplet_removal.changed is true
+
+    - name: Check our firewall for the droplet being removed
+      community.digitalocean.digital_ocean_firewall_info:
+        oauth_token: "{{ do_api_key }}"
+        name: "{{ firewall_name }}"
+      register: firewall_settings_removal
+
+    - name: Verify details of firewall with droplet
+      ansible.builtin.assert:
+        that:
+          - firewall_settings_removal is defined
+          - "{{ (firewall_settings_removal.data | map(attribute='droplet_ids'))[0] | length == 0 }}"
+          - "{{ firewall_droplet.data.droplet.id }} not in {{ firewall_settings_removal.data | map(attribute='droplet_ids') }}"
 
   always:
+
+    - name: Delete the Firewall (always)
+      community.digitalocean.digital_ocean_firewall:
+        oauth_token: "{{ do_api_key }}"
+        name: "{{ firewall_name }}"
+        state: absent
 
     - name: Delete the Droplet (always)
       community.digitalocean.digital_ocean_droplet:

--- a/tests/integration/targets/digital_ocean_droplet/tasks/main.yml
+++ b/tests/integration/targets/digital_ocean_droplet/tasks/main.yml
@@ -242,30 +242,9 @@
         oauth_token: "{{ do_api_key }}"
         name: "{{ firewall_name }}"
         state: present
-        inbound_rules:
-          - protocol: "tcp"
-            ports: "80"
-            sources:
-              addresses: ["0.0.0.0/0", "::/0"]
-          - protocol: "tcp"
-            ports: "443"
-            sources:
-              addresses: ["0.0.0.0/0", "::/0"]
-        outbound_rules:
-          - protocol: "tcp"
-            ports: "1-65535"
-            destinations:
-              addresses: ["0.0.0.0/0", "::/0"]
-          - protocol: "udp"
-            ports: "1-65535"
-            destinations:
-              addresses: ["0.0.0.0/0", "::/0"]
-          - protocol: "icmp"
-            ports: "1-65535"
-            destinations:
-              addresses: ["0.0.0.0/0", "::/0"]
+        inbound_rules: "{{ firewall_inbound_rules }}"
+        outbound_rules: "{{ firewall_outbound_rules }}"
         droplet_ids: []
-        tags: ["testing"]
       register: testing_firewall
 
     - name: Verify firewall was created


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #159 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
digital_ocean_droplet
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This adds new functionality to the droplet module in the following way:
- for state=absent we require unique_name: true to avoid the potential for destorying multiple/incorrect droplet(s)
- we can now add firewalls to droplets when creating them, or we can apply new/remove old firewall rules by name. 
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
