### PR TITLE
Fix return values for digital_ocean_kubernetes module (#174)

### DIFF
--- a/changelogs/fragments/174-return-value-fix.yml
+++ b/changelogs/fragments/174-return-value-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+        - digital_ocean_kubernetes - fix return value consistency (https://github.com/ansible-collections/community.digitalocean/issues/174)

--- a/changelogs/fragments/174-return-value-fix.yml
+++ b/changelogs/fragments/174-return-value-fix.yml
@@ -1,2 +1,2 @@
 bugfixes:
-        - digital_ocean_kubernetes - fix return value consistency (https://github.com/ansible-collections/community.digitalocean/issues/174)
+  - digital_ocean_kubernetes - fix return value consistency (https://github.com/ansible-collections/community.digitalocean/issues/174).

--- a/plugins/modules/digital_ocean_kubernetes.py
+++ b/plugins/modules/digital_ocean_kubernetes.py
@@ -391,7 +391,7 @@ class DOKubernetes(object):
         # Add the kubeconfig to the return
         if self.return_kubeconfig:
             json_data["kubeconfig"] = self.get_kubernetes_kubeconfig()
-        self.module.exit_json(changed=True, data=json_data)
+        self.module.exit_json(changed=True, data=json_data["kubernetes_cluster"])
 
     def delete(self):
         """Deletes a DigitalOcean Kubernetes cluster
@@ -404,12 +404,12 @@ class DOKubernetes(object):
             response = self.rest.delete(
                 "kubernetes/clusters/{0}".format(json_data["id"])
             )
-            json_data = response.json
             if response.status_code == 204:
-                self.module.exit_json(changed=True, msg="Kubernetes cluster deleted")
+                self.module.exit_json(changed=True, data=json_data, msg="Kubernetes cluster deleted")
             self.module.fail_json(
                 changed=False, msg="Failed to delete Kubernetes cluster"
             )
+            json_data = response.json
         else:
             self.module.exit_json(changed=False, msg="Kubernetes cluster not found")
 

--- a/plugins/modules/digital_ocean_kubernetes.py
+++ b/plugins/modules/digital_ocean_kubernetes.py
@@ -405,7 +405,9 @@ class DOKubernetes(object):
                 "kubernetes/clusters/{0}".format(json_data["id"])
             )
             if response.status_code == 204:
-                self.module.exit_json(changed=True, data=json_data, msg="Kubernetes cluster deleted")
+                self.module.exit_json(
+                    changed=True, data=json_data, msg="Kubernetes cluster deleted"
+                )
             self.module.fail_json(
                 changed=False, msg="Failed to delete Kubernetes cluster"
             )


### PR DESCRIPTION
SUMMARY
The return values for the digital_ocean_kubernetes module are made consistent with what is documented. This change removes the extra "kubernetes_cluster" key that was present only when creating a new resource (changes were already consistent). Also adds the same return values when a resource is deleted so you can still use those values dynamically for further tasks.

Fixes #174 but only for the digital_ocean_kubernetes module.

ISSUE TYPE
- Bugfix Pull Request

COMPONENT NAME
digital_ocean_kubernetes
