### PR TITLE
Release 1.14.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,24 @@ Community DigitalOcean Release Notes
 .. contents:: Topics
 
 
+v1.14.0
+=======
+
+Minor Changes
+-------------
+
+- digital_ocean_kubernetes_info - switching C(changed=True) to C(changed=False) since getting information is read-only in nature (https://github.com/ansible-collections/community.digitalocean/issues/204).
+
+Bugfixes
+--------
+
+- Update README.md with updated Droplet examples (https://github.com/ansible-collections/community.digitalocean/issues/199).
+- digital_ocean_cdn_endpoints - defaulting optional string parameters as strings (https://github.com/ansible-collections/community.digitalocean/issues/205).
+- digital_ocean_cdn_endpoints - updating Spaces endpoint for the integration test (https://github.com/ansible-collections/community.digitalocean/issues/205).
+- digital_ocean_droplet - ensure that Droplet creation is successful (https://github.com/ansible-collections/community.digitalocean/issues/197).
+- digital_ocean_droplet - fixing project assignment for the C(unique_name=False) case (https://github.com/ansible-collections/community.digitalocean/issues/201).
+- digital_ocean_droplet - update Droplet examples (https://github.com/ansible-collections/community.digitalocean/issues/199).
+
 v1.13.0
 =======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -152,6 +152,27 @@ releases:
     - 190-kubernetes-ha.yaml
     - 194-droplet-sleep-variable.yaml
     release_date: '2021-12-10'
+  1.14.0:
+    changes:
+      bugfixes:
+      - Update README.md with updated Droplet examples (https://github.com/ansible-collections/community.digitalocean/issues/199).
+      - digital_ocean_cdn_endpoints - defaulting optional string parameters as strings
+        (https://github.com/ansible-collections/community.digitalocean/issues/205).
+      - digital_ocean_cdn_endpoints - updating Spaces endpoint for the integration
+        test (https://github.com/ansible-collections/community.digitalocean/issues/205).
+      - digital_ocean_droplet - ensure that Droplet creation is successful (https://github.com/ansible-collections/community.digitalocean/issues/197).
+      - digital_ocean_droplet - fixing project assignment for the C(unique_name=False)
+        case (https://github.com/ansible-collections/community.digitalocean/issues/201).
+      - digital_ocean_droplet - update Droplet examples (https://github.com/ansible-collections/community.digitalocean/issues/199).
+      minor_changes:
+      - digital_ocean_kubernetes_info - switching C(changed=True) to C(changed=False)
+        since getting information is read-only in nature (https://github.com/ansible-collections/community.digitalocean/issues/204).
+    fragments:
+    - 199-update-droplet-docs-examples.yaml
+    - 201-droplet-unique-name.yaml
+    - 204-kubernetes-tags-and-info.yaml
+    - 205-cdn-endpoints.yaml
+    release_date: '2021-12-20'
   1.2.0:
     changes:
       bugfixes:

--- a/changelogs/fragments/199-update-droplet-docs-examples.yaml
+++ b/changelogs/fragments/199-update-droplet-docs-examples.yaml
@@ -1,4 +1,0 @@
-bugfixes:
-  - Update README.md with updated Droplet examples (https://github.com/ansible-collections/community.digitalocean/issues/199).
-  - digital_ocean_droplet - update Droplet examples (https://github.com/ansible-collections/community.digitalocean/issues/199).
-  - digital_ocean_droplet - ensure that Droplet creation is successful (https://github.com/ansible-collections/community.digitalocean/issues/197).

--- a/changelogs/fragments/201-droplet-unique-name.yaml
+++ b/changelogs/fragments/201-droplet-unique-name.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - digital_ocean_droplet - fixing project assignment for the C(unique_name=False) case (https://github.com/ansible-collections/community.digitalocean/issues/201).

--- a/changelogs/fragments/204-kubernetes-tags-and-info.yaml
+++ b/changelogs/fragments/204-kubernetes-tags-and-info.yaml
@@ -1,2 +1,0 @@
-minor_changes:
-  - digital_ocean_kubernetes_info - switching C(changed=True) to C(changed=False) since getting information is read-only in nature (https://github.com/ansible-collections/community.digitalocean/issues/204).

--- a/changelogs/fragments/205-cdn-endpoints.yaml
+++ b/changelogs/fragments/205-cdn-endpoints.yaml
@@ -1,3 +1,0 @@
-bugfixes:
-  - digital_ocean_cdn_endpoints - updating Spaces endpoint for the integration test (https://github.com/ansible-collections/community.digitalocean/issues/205).
-  - digital_ocean_cdn_endpoints - defaulting optional string parameters as strings (https://github.com/ansible-collections/community.digitalocean/issues/205).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -34,7 +34,7 @@ tags:
   - digitalocean
   - cloud
   - droplet
-version: 1.13.0
+version: 1.14.0
 build_ignore:
   - .DS_Store
   - '*.tar.gz'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Release 1.14.0; minor changes to `digital_ocean_kubernetes_info` and bugfixes for `digital_ocean_cdn_endpoints` and `digital_ocean_droplet`.

