### PR TITLE
Fix droplet creation with firewall

### DIFF
--- a/changelogs/fragments/202-droplet-create-with-firewall.yaml
+++ b/changelogs/fragments/202-droplet-create-with-firewall.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - digital_ocean_droplet - fix droplets creating without specified firewall (https://github.com/ansible-collections/community.digitalocean/issues/202).

--- a/plugins/modules/digital_ocean_droplet.py
+++ b/plugins/modules/digital_ocean_droplet.py
@@ -368,7 +368,10 @@ class DODroplet(object):
         if rule is None:
             err = "Failed to find firewalls: {0}".format(self.module.params["firewall"])
             return err
-        json_data = self.get_droplet_by_name()
+        if not self.unique_name:
+            json_data = self.get_droplet_by_name()
+        else:
+            json_data = self.get_droplet()
         if json_data is not None:
             request_params = {}
             droplet = json_data.get("droplet", None)
@@ -393,7 +396,10 @@ class DODroplet(object):
         return None
 
     def remove_droplet_from_firewalls(self):
-        json_data = self.get_droplet()
+        if self.unique_name:
+            json_data = self.get_droplet()
+        else:
+            json_data = self.get_droplet_by_name()
         if json_data is not None:
             request_params = {}
             droplet = json_data.get("droplet", None)

--- a/plugins/modules/digital_ocean_droplet.py
+++ b/plugins/modules/digital_ocean_droplet.py
@@ -368,7 +368,7 @@ class DODroplet(object):
         if rule is None:
             err = "Failed to find firewalls: {0}".format(self.module.params["firewall"])
             return err
-        json_data = self.get_droplet()
+        json_data = self.get_droplet_by_name()
         if json_data is not None:
             request_params = {}
             droplet = json_data.get("droplet", None)
@@ -387,6 +387,9 @@ class DODroplet(object):
                             droplet_id, rule[firewall]["id"]
                         )
                         return err
+        else:
+            err = f"Failed to find droplet data. got: {json_data}"
+            return err
         return None
 
     def remove_droplet_from_firewalls(self):
@@ -490,6 +493,12 @@ class DODroplet(object):
     def get_droplet(self):
         json_data = self.get_by_id(self.module.params["id"])
         if not json_data and self.unique_name:
+            json_data = self.get_by_name(self.module.params["name"])
+        return json_data
+
+    def get_droplet_by_name(self):
+        json_data = self.get_by_id(self.module.params["id"])
+        if not json_data:
             json_data = self.get_by_name(self.module.params["name"])
         return json_data
 
@@ -789,7 +798,6 @@ class DODroplet(object):
             )
         # Add droplet to firewall if specified
         if self.module.params["firewall"] is not None:
-            # raise Exception(self.module.params["firewall"])
             firewall_add = self.add_droplet_to_firewalls()
             if firewall_add is not None:
                 self.module.fail_json(

--- a/tests/integration/targets/digital_ocean_droplet/tasks/main.yml
+++ b/tests/integration/targets/digital_ocean_droplet/tasks/main.yml
@@ -449,12 +449,6 @@
           - "{{ (firewall_settings_removal.data | map(attribute='droplet_ids'))[0] | length == 0 }}"
           - "{{ firewall_droplet.data.droplet.id }} not in {{ firewall_settings_removal.data | map(attribute='droplet_ids') }}"
 
-    - name: Delete the Firewall (always)
-      community.digitalocean.digital_ocean_firewall:
-        oauth_token: "{{ do_api_key }}"
-        name: "{{ firewall_name }}"
-        state: absent
-
     - name: Delete the Droplet (always)
       community.digitalocean.digital_ocean_droplet:
         oauth_token: "{{ do_api_key }}"

--- a/tests/integration/targets/digital_ocean_droplet/tasks/main.yml
+++ b/tests/integration/targets/digital_ocean_droplet/tasks/main.yml
@@ -385,7 +385,7 @@
           - testing_firewall is defined
           - testing_firewall.changed is true
 
-    - name: Create a new droplet and add to the above firewall
+    - name: Create a new droplet and add to the above firewall (unique_name)
       community.digitalocean.digital_ocean_droplet:
         oauth_token: "{{ do_api_key }}"
         state: present
@@ -448,6 +448,85 @@
           - firewall_settings_removal is defined
           - "{{ (firewall_settings_removal.data | map(attribute='droplet_ids'))[0] | length == 0 }}"
           - "{{ firewall_droplet.data.droplet.id }} not in {{ firewall_settings_removal.data | map(attribute='droplet_ids') }}"
+
+    - name: Delete the Firewall (always)
+      community.digitalocean.digital_ocean_firewall:
+        oauth_token: "{{ do_api_key }}"
+        name: "{{ firewall_name }}"
+        state: absent
+
+    - name: Delete the Droplet (always)
+      community.digitalocean.digital_ocean_droplet:
+        oauth_token: "{{ do_api_key }}"
+        state: absent
+        name: "{{ droplet_name }}"
+        unique_name: true
+        region: "{{ do_region }}"
+      ignore_errors: true  # Should this fail, we'll clean it up next run
+
+    - name: non-unique droplet firewall tests
+      block:
+        - name: Create a new droplet and add to the above firewall (non-unique name)
+          community.digitalocean.digital_ocean_droplet:
+            oauth_token: "{{ do_api_key }}"
+            state: present
+            name: "{{ droplet_name }}"
+            firewall: ["{{ firewall_name }}"]
+            size: "{{ droplet_size }}"
+            region: "{{ do_region }}"
+            image: "{{ droplet_image }}"
+            wait_timeout: 500
+          register: firewall_droplet_non_unique
+
+        - name: Verify the droplet has created and has firewall applied
+          ansible.builtin.assert:
+            that:
+              - firewall_droplet_non_unique is defined
+              - firewall_droplet_non_unique.changed is true
+
+        - name: Check our firewall for the new droplet
+          community.digitalocean.digital_ocean_firewall_info:
+            oauth_token: "{{ do_api_key }}"
+            name: "{{ firewall_name }}"
+          register: firewall_settings_non_unique
+
+        - name: Verify details of firewall with droplet
+          ansible.builtin.assert:
+            that:
+              - firewall_settings_non_unique is defined
+              - "{{ (firewall_settings_non_unique.data | map(attribute='droplet_ids'))[0] | length > 0 }}"
+              - "{{ firewall_droplet_non_unique.data.droplet.id }} in {{ (firewall_settings_non_unique.data | map(attribute='droplet_ids'))[0] }}"
+
+        - name: Rerun on above droplet and remove firewall (non-unique name)
+          community.digitalocean.digital_ocean_droplet:
+            oauth_token: "{{ do_api_key }}"
+            state: present
+            name: "{{ droplet_name }}"
+            firewall: []
+            size: "{{ droplet_size }}"
+            region: "{{ do_region }}"
+            image: "{{ droplet_image }}"
+            wait_timeout: 500
+          register: firewall_droplet_removal_non_unique
+
+        - name: Verify things were changed for firewall removal
+          ansible.builtin.assert:
+            that:
+              - firewall_droplet_removal_non_unique is defined
+              - firewall_droplet_removal_non_unique.changed is true
+
+        - name: Check our firewall for the droplet being removed
+          community.digitalocean.digital_ocean_firewall_info:
+            oauth_token: "{{ do_api_key }}"
+            name: "{{ firewall_name }}"
+          register: firewall_settings_removal_non_unique
+
+        - name: Verify details of firewall with droplet
+          ansible.builtin.assert:
+            that:
+              - firewall_settings_removal_non_unique is defined
+              - "{{ (firewall_settings_removal_non_unique.data | map(attribute='droplet_ids'))[0] | length == 0 }}"
+              - "{{ firewall_droplet_non_unique.data.droplet.id }} not in {{ firewall_settings_removal_non_unique.data | map(attribute='droplet_ids') }}"
 
   always:
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This adds in a new function (get_droplet_by_name) to handle obtaining droplet data to add to firewall(s). Previously the bug came from the fact that we needed `unique: true` in order to look for the droplet by name. Using that will work as expected, but that shouldn't be required here. In the case of adding the droplet to the firewall, I am creating a separate (but similar) function to get the droplet by ID and if that yields nothing, we then use the name supplied to determine what to add our firewall to.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #202 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
digital_ocean_droplet

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
