### PR TITLE
make droplet firewall adding/removing report changed properly

### DIFF
--- a/changelogs/fragments/219-droplet-firewall-changed-reporting.yaml
+++ b/changelogs/fragments/219-droplet-firewall-changed-reporting.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - digital_ocean_droplet - fix reporting of changed state when ``firewall`` argument is present (https://github.com/ansible-collections/community.digitalocean/pull/219)
+  - digital_ocean_droplet - fix reporting of changed state when ``firewall`` argument is present (https://github.com/ansible-collections/community.digitalocean/pull/219).

--- a/changelogs/fragments/219-droplet-firewall-changed-reporting.yaml
+++ b/changelogs/fragments/219-droplet-firewall-changed-reporting.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - digital_ocean_droplet - fix reporting of changed state when ``firewall`` argument is present
+  - digital_ocean_droplet - fix reporting of changed state when ``firewall`` argument is present (https://github.com/ansible-collections/community.digitalocean/pull/219)

--- a/changelogs/fragments/219-droplet-firewall-changed-reporting.yaml
+++ b/changelogs/fragments/219-droplet-firewall-changed-reporting.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - digital_ocean_droplet - fix reporting of changed state when ``firewall`` argument is present

--- a/plugins/modules/digital_ocean_droplet.py
+++ b/plugins/modules/digital_ocean_droplet.py
@@ -415,6 +415,7 @@ class DODroplet(object):
                             droplet_id, firewall["id"]
                         )
                         return err, changed
+                    changed = True
         return None, changed
 
     def get_by_id(self, droplet_id):
@@ -683,7 +684,7 @@ class DODroplet(object):
                             msg=firewall_add,
                             data={"droplet": droplet, "firewall": firewall_add},
                         )
-                    firewall_changed = add_changed
+                    firewall_changed = firewall_changed or add_changed
                 firewall_remove, remove_changed = self.remove_droplet_from_firewalls()
                 if firewall_remove is not None:
                     self.module.fail_json(
@@ -691,7 +692,7 @@ class DODroplet(object):
                         msg=firewall_remove,
                         data={"droplet": droplet, "firewall": firewall_remove},
                     )
-                    firewall_changed = firewall_changed or add_changed
+                firewall_changed = firewall_changed or add_changed
                 self.module.exit_json(
                     changed=firewall_changed,
                     data={"droplet": droplet},

--- a/plugins/modules/digital_ocean_droplet.py
+++ b/plugins/modules/digital_ocean_droplet.py
@@ -692,7 +692,7 @@ class DODroplet(object):
                         msg=firewall_remove,
                         data={"droplet": droplet, "firewall": firewall_remove},
                     )
-                firewall_changed = firewall_changed or add_changed
+                firewall_changed = firewall_changed or remove_changed
                 self.module.exit_json(
                     changed=firewall_changed,
                     data={"droplet": droplet},

--- a/tests/integration/targets/digital_ocean_droplet/tasks/main.yml
+++ b/tests/integration/targets/digital_ocean_droplet/tasks/main.yml
@@ -436,6 +436,25 @@
           - "{{ (firewall_settings.data | map(attribute='droplet_ids'))[0] | length > 0 }}"
           - "{{ firewall_droplet.data.droplet.id }} in {{ (firewall_settings.data | map(attribute='droplet_ids'))[0] }}"
 
+    - name: Rerun on above droplet without removing firewall
+      community.digitalocean.digital_ocean_droplet:
+        oauth_token: "{{ do_api_key }}"
+        state: present
+        name: "{{ droplet_name }}"
+        unique_name: true
+        firewall: ["{{ firewall_name }}"]
+        size: "{{ droplet_size }}"
+        region: "{{ do_region }}"
+        image: "{{ droplet_image }}"
+        wait_timeout: 500
+      register: firewall_droplet_unchanged
+
+    - name: Verify things were not changed when firewall was present but unchanged
+      ansible.builtin.assert:
+        that:
+          - firewall_droplet_unchanged is defined
+          - firewall_droplet_unchanged.changed is false
+
     - name: Rerun on above droplet and remove firewall
       community.digitalocean.digital_ocean_droplet:
         oauth_token: "{{ do_api_key }}"


### PR DESCRIPTION
##### SUMMARY
When using the droplet module, the presence of the `firewall` argument causes the module to always report changed=True, even when no changes were necessary/made. This patch causes it to track if the droplet needed to be added or removed from any firewalls and reports changed appropriately. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
digital_ocean_droplet

##### ADDITIONAL INFORMATION
Running the droplet module even with an empty list passed to firewalls returns changed=true.

```
- name: Show a droplet always changing just because firewall is present
  community.digitalocean.digital_ocean_droplet:
    state: present
    oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
    id: 123
    name: mydroplet
    size: s-1vcpu-1gb
    region: sfo3
    image: ubuntu-20-04-x64
    firewall: []
    wait_timeout: 500
```