### PR TITLE
Creating 1.18.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,16 @@ Community DigitalOcean Release Notes
 .. contents:: Topics
 
 
+v1.18.0
+=======
+
+Minor Changes
+-------------
+
+- ci - adding stable-2.13 to sanity and unit testing (https://github.com/ansible-collections/community.digitalocean/issues/239).
+- digital_ocean_spaces - set C(no_log=True) for C(aws_access_key_id) parameter (https://github.com/ansible-collections/community.digitalocean/issues/243).
+- digital_ocean_spaces_info - set C(no_log=True) for C(aws_access_key_id) parameter (https://github.com/ansible-collections/community.digitalocean/issues/243).
+
 v1.17.0
 =======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -226,6 +226,18 @@ releases:
     fragments:
     - 237-parameterize-do-api-baseurl.yaml
     release_date: '2022-04-28'
+  1.18.0:
+    changes:
+      minor_changes:
+      - ci - adding stable-2.13 to sanity and unit testing (https://github.com/ansible-collections/community.digitalocean/issues/239).
+      - digital_ocean_spaces - set C(no_log=True) for C(aws_access_key_id) parameter
+        (https://github.com/ansible-collections/community.digitalocean/issues/243).
+      - digital_ocean_spaces_info - set C(no_log=True) for C(aws_access_key_id) parameter
+        (https://github.com/ansible-collections/community.digitalocean/issues/243).
+    fragments:
+    - 239-ci-stable-2.13.yaml
+    - 243-no-log-spaces-access-key-id.yaml
+    release_date: '2022-05-03'
   1.2.0:
     changes:
       bugfixes:

--- a/changelogs/fragments/239-ci-stable-2.13.yaml
+++ b/changelogs/fragments/239-ci-stable-2.13.yaml
@@ -1,2 +1,0 @@
-minor_changes:
-  - ci - adding stable-2.13 to sanity and unit testing (https://github.com/ansible-collections/community.digitalocean/issues/239).

--- a/changelogs/fragments/243-no-log-spaces-access-key-id.yaml
+++ b/changelogs/fragments/243-no-log-spaces-access-key-id.yaml
@@ -1,3 +1,0 @@
-minor_changes:
-  - digital_ocean_spaces - set C(no_log=True) for C(aws_access_key_id) parameter (https://github.com/ansible-collections/community.digitalocean/issues/243).
-  - digital_ocean_spaces_info - set C(no_log=True) for C(aws_access_key_id) parameter (https://github.com/ansible-collections/community.digitalocean/issues/243).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -41,7 +41,7 @@ tags:
   - digitalocean
   - cloud
   - droplet
-version: 1.17.0
+version: 1.18.0
 build_ignore:
   - .DS_Store
   - '*.tar.gz'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Release 1.18.0; adding `stable-2.13` to CI for sanity and unit testing and adding`no_log=True` to `aws_access_key_id` in the Spaces modules.

