### PR TITLE
Remove non-API params; fix DOCUMENTATION and EXAMPLES; consistently reference $DO_API_TOKEN

### DIFF
--- a/changelogs/fragments/248-oauth-token-consistency.yaml
+++ b/changelogs/fragments/248-oauth-token-consistency.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - digital_ocean - reference C(DO_API_TOKEN) consistently in module documentation and examples (https://github.com/ansible-collections/community.digitalocean/issues/248).

--- a/changelogs/fragments/251-cdn-endpoints-examples-wrong-module.yaml
+++ b/changelogs/fragments/251-cdn-endpoints-examples-wrong-module.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - digital_ocean_cdn_endpoints - use the correct module name in the C(EXAMPLES) (https://github.com/ansible-collections/community.digitalocean/issues/251).

--- a/changelogs/fragments/252-cdn-endpoints-http-500.yaml
+++ b/changelogs/fragments/252-cdn-endpoints-http-500.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - digital_ocean_cdn_endpoints - remove non-API parameters before posting to the API (https://github.com/ansible-collections/community.digitalocean/issues/252).

--- a/plugins/modules/digital_ocean.py
+++ b/plugins/modules/digital_ocean.py
@@ -129,18 +129,18 @@ EXAMPLES = r"""
 - name: Ensure a SSH key is present
   community.digitalocean.digital_ocean:
     state: present
+    oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
     command: ssh
     name: my_ssh_key
     ssh_pub_key: 'ssh-rsa AAAA...'
-    api_token: XXX
 
 # Will return the droplet details including the droplet id (used for idempotence)
 - name: Create a new Droplet
   community.digitalocean.digital_ocean:
     state: present
+    oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
     command: droplet
     name: mydroplet
-    api_token: XXX
     size_id: 2gb
     region_id: ams2
     image_id: fedora-19-x64
@@ -160,10 +160,10 @@ EXAMPLES = r"""
 - name: Ensure a droplet is present
   community.digitalocean.digital_ocean:
     state: present
+    oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
     command: droplet
     id: 123
     name: mydroplet
-    api_token: XXX
     size_id: 2gb
     region_id: ams2
     image_id: fedora-19-x64
@@ -177,9 +177,9 @@ EXAMPLES = r"""
 - name: Create a droplet with ssh key
   community.digitalocean.digital_ocean:
     state: present
+    oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
     ssh_key_ids: 123,456
     name: mydroplet
-    api_token: XXX
     size_id: 2gb
     region_id: ams2
     image_id: fedora-19-x64

--- a/plugins/modules/digital_ocean.py
+++ b/plugins/modules/digital_ocean.py
@@ -261,9 +261,9 @@ class Droplet(JsonfyMixIn):
             self.power_on()
 
         if wait:
-            end_time = time.time() + wait_timeout
-            while time.time() < end_time:
-                time.sleep(min(20, end_time - time.time()))
+            end_time = time.monotonic() + wait_timeout
+            while time.monotonic() < end_time:
+                time.sleep(10)
                 self.update_attr()
                 if self.is_powered_on():
                     if not self.ip_address:

--- a/plugins/modules/digital_ocean_block_storage.py
+++ b/plugins/modules/digital_ocean_block_storage.py
@@ -194,9 +194,9 @@ class DOBlockStorage(object):
 
     def poll_action_for_complete_status(self, action_id):
         url = "actions/{0}".format(action_id)
-        end_time = time.time() + self.module.params["timeout"]
-        while time.time() < end_time:
-            time.sleep(2)
+        end_time = time.monotonic() + self.module.params["timeout"]
+        while time.monotonic() < end_time:
+            time.sleep(10)
             response = self.rest.get(url)
             status = response.status_code
             json = response.json

--- a/plugins/modules/digital_ocean_block_storage.py
+++ b/plugins/modules/digital_ocean_block_storage.py
@@ -84,8 +84,8 @@ EXAMPLES = r"""
 - name: Create new Block Storage
   community.digitalocean.digital_ocean_block_storage:
     state: present
+    oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
     command: create
-    api_token: <TOKEN>
     region: nyc1
     block_size: 10
     volume_name: nyc1-block-storage
@@ -93,8 +93,8 @@ EXAMPLES = r"""
 - name: Create new Block Storage (and assign to Project "test")
   community.digitalocean.digital_ocean_block_storage:
     state: present
+    oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
     command: create
-    api_token: <TOKEN>
     region: nyc1
     block_size: 10
     volume_name: nyc1-block-storage
@@ -103,8 +103,8 @@ EXAMPLES = r"""
 - name: Resize an existing Block Storage
   community.digitalocean.digital_ocean_block_storage:
     state: present
+    oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
     command: create
-    api_token: <TOKEN>
     region: nyc1
     block_size: 20
     volume_name: nyc1-block-storage
@@ -112,16 +112,16 @@ EXAMPLES = r"""
 - name: Delete Block Storage
   community.digitalocean.digital_ocean_block_storage:
     state: absent
+    oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
     command: create
-    api_token: <TOKEN>
     region: nyc1
     volume_name: nyc1-block-storage
 
 - name: Attach Block Storage to a Droplet
   community.digitalocean.digital_ocean_block_storage:
     state: present
+    oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
     command: attach
-    api_token: <TOKEN>
     volume_name: nyc1-block-storage
     region: nyc1
     droplet_id: <ID>
@@ -129,8 +129,8 @@ EXAMPLES = r"""
 - name: Detach Block Storage from a Droplet
   community.digitalocean.digital_ocean_block_storage:
     state: absent
+    oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
     command: attach
-    api_token: <TOKEN>
     volume_name: nyc1-block-storage
     region: nyc1
     droplet_id: <ID>

--- a/plugins/modules/digital_ocean_cdn_endpoints.py
+++ b/plugins/modules/digital_ocean_cdn_endpoints.py
@@ -56,20 +56,20 @@ extends_documentation_fragment:
 
 EXAMPLES = r"""
 - name: Create DigitalOcean CDN Endpoint
-  community.digitalocean.digital_ocean_cdn_endpoints_info:
+  community.digitalocean.digital_ocean_cdn_endpoints:
     state: present
     oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
     origin: mamercad.nyc3.digitaloceanspaces.com
 
 - name: Update DigitalOcean CDN Endpoint (change ttl to 600, default is 3600)
-  community.digitalocean.digital_ocean_cdn_endpoints_info:
+  community.digitalocean.digital_ocean_cdn_endpoints:
     state: present
     oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
     origin: mamercad.nyc3.digitaloceanspaces.com
     ttl: 600
 
 - name: Delete DigitalOcean CDN Endpoint
-  community.digitalocean.digital_ocean_cdn_endpoints_info:
+  community.digitalocean.digital_ocean_cdn_endpoints:
     state: absent
     oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
     origin: mamercad.nyc3.digitaloceanspaces.com
@@ -219,6 +219,12 @@ class DOCDNEndpoint(object):
 def run(module):
     state = module.params.pop("state")
     c = DOCDNEndpoint(module)
+
+    # Pop these away (don't need them beyond DOCDNEndpoint)
+    module.params.pop("baseurl")
+    module.params.pop("validate_certs")
+    module.params.pop("timeout")
+
     if state == "present":
         c.create()
     elif state == "absent":

--- a/plugins/modules/digital_ocean_domain_record.py
+++ b/plugins/modules/digital_ocean_domain_record.py
@@ -92,8 +92,8 @@ notes:
 EXAMPLES = """
 - name: Create default A record for example.com
   community.digitalocean.digital_ocean_domain_record:
-    oauth_token: xxxx
     state: present
+    oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
     domain: example.com
     type: A
     name: "@"
@@ -101,8 +101,8 @@ EXAMPLES = """
 
 - name: Create A record for www
   community.digitalocean.digital_ocean_domain_record:
-    oauth_token: xxxx
     state: present
+    oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
     domain: example.com
     type: A
     name: www
@@ -110,8 +110,8 @@ EXAMPLES = """
 
 - name: Update A record for www based on name/type/data
   community.digitalocean.digital_ocean_domain_record:
-    oauth_token: xxxx
     state: present
+    oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
     domain: example.com
     type: A
     name: www
@@ -120,8 +120,8 @@ EXAMPLES = """
 
 - name: Update A record for www based on record_id
   community.digitalocean.digital_ocean_domain_record:
-    oauth_token: xxxx
     state: present
+    oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
     domain: example.com
     record_id: 123456
     type: A
@@ -131,8 +131,8 @@ EXAMPLES = """
 
 - name: Remove www record based on name/type/data
   community.digitalocean.digital_ocean_domain_record:
-    oauth_token: xxxx
     state: absent
+    oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
     domain: example.com
     type: A
     name: www
@@ -140,15 +140,15 @@ EXAMPLES = """
 
 - name: Remove www record based on record_id
   community.digitalocean.digital_ocean_domain_record:
-    oauth_token: xxxx
     state: absent
+    oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
     domain: example.com
     record_id: 1234567
 
 - name: Create MX record with priority 10 for example.com
   community.digitalocean.digital_ocean_domain_record:
-    oauth_token: xxxx
     state: present
+    oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
     domain: example.com
     type: MX
     data: mail1.example.com

--- a/plugins/modules/digital_ocean_domain_record_info.py
+++ b/plugins/modules/digital_ocean_domain_record_info.py
@@ -51,20 +51,20 @@ EXAMPLES = r"""
 - name: Retrieve all domain records for example.com
   community.digitalocean.digital_ocean_domain_record_info:
     state: present
-    oauth_token: xxxx
+    oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
     domain: example.com
 
 - name: Get specific domain record by ID
   community.digitalocean.digital_ocean_domain_record_info:
     state: present
-    oauth_token: xxxx
+    oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
     record_id: 12345789
   register: result
 
 - name: Retrieve all A domain records for example.com
   community.digitalocean.digital_ocean_domain_record_info:
     state: present
-    oauth_token: xxxx
+    oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
     domain: example.com
     type: A
 """

--- a/plugins/modules/digital_ocean_kubernetes.py
+++ b/plugins/modules/digital_ocean_kubernetes.py
@@ -339,12 +339,12 @@ class DOKubernetes(object):
 
     def ensure_running(self):
         """Waits for the newly created DigitalOcean Kubernetes cluster to be running"""
-        end_time = time.time() + self.wait_timeout
-        while time.time() < end_time:
+        end_time = time.monotonic() + self.wait_timeout
+        while time.monotonic() < end_time:
             cluster = self.get_by_id()
             if cluster["kubernetes_cluster"]["status"]["state"] == "running":
                 return cluster
-            time.sleep(min(2, end_time - time.time()))
+            time.sleep(10)
         self.module.fail_json(msg="Wait for Kubernetes cluster to be running")
 
     def create(self):

--- a/plugins/modules/digital_ocean_load_balancer.py
+++ b/plugins/modules/digital_ocean_load_balancer.py
@@ -504,7 +504,7 @@ class DOLoadBalancer(object):
                         self.id, self.region
                     )
                 )
-            time.sleep(min(10, end_time - time.monotonic()))
+            time.sleep(10)
         self.module.fail_json(
             msg="Timed out waiting for Load Balancer {0} in {1} to be active".format(
                 self.id, self.region

--- a/tests/integration/targets/digital_ocean_cdn_endpoints/defaults/main.yml
+++ b/tests/integration/targets/digital_ocean_cdn_endpoints/defaults/main.yml
@@ -1,2 +1,4 @@
-endpoint: gh-ci-space.nyc3.cdn.digitaloceanspaces.com
-origin: gh-ci-space.nyc3.digitaloceanspaces.com
+# endpoint: gh-ci-space.nyc3.cdn.digitaloceanspaces.com
+# origin: gh-ci-space.nyc3.digitaloceanspaces.com
+endpoint: ansible-gh-ci-space.nyc3.cdn.digitaloceanspaces.com
+origin: ansible-gh-ci-space.nyc3.digitaloceanspaces.com


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove non-DO API parameters before POSTing the create to the API and use the correct module name in the `EXAMPLES`. Consistently reference `$DO_API_TOKEN` in the `DOCUMENTATION` and `EXAMPLES`. Switch from `time.time()` to `time.monotonic()` as it seems like some of the integration tests were being affected by clock skew; also, simplify the polling interval -- we can spare a few seconds to look at `time.sleep(10)` versus `time.sleep(min(10, end_time - time.monotonic()))`.

Fixes #251 and #252 and #248.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
* `digital_ocean`
* `digital_ocean_block_storage`
* `digital_ocean_cdn_endpoints`
* `digital_ocean_domain_record`
* `digital_ocean_domain_record_info`

