### PR TITLE
Added support for creating a load balancer with a tag

### DIFF
--- a/changelogs/fragments/258-load-balancer-with-tag.yml
+++ b/changelogs/fragments/258-load-balancer-with-tag.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - digital_ocean_load_balancer - Allow creating a load balancer and associating droplets by tag as an alternative to ``droplet_ids``. 

--- a/plugins/modules/digital_ocean_load_balancer.py
+++ b/plugins/modules/digital_ocean_load_balancer.py
@@ -780,6 +780,7 @@ def main():
         required_if=(
             [
                 ("state", "present", ["forwarding_rules"]),
+                ("state", "present", ["tag", "droplet_ids"], True),
             ]
         ),
         # Droplet ID and tag are mutually exclusive, check that both have not been defined
@@ -788,7 +789,6 @@ def main():
                 ("tag", "droplet_ids"),
             ]
         ),
-        required_one_of=[("tag", "droplet_ids")],
         supports_check_mode=True,
     )
 

--- a/plugins/modules/digital_ocean_load_balancer.py
+++ b/plugins/modules/digital_ocean_load_balancer.py
@@ -606,12 +606,6 @@ class DOLoadBalancer(object):
                     ),
                 )
 
-        # Droplet ID and tag are mutually exclusive, check that both have not been defined
-        if self.module.params.get('droplet_ids') is not None and self.module.params.get('tag') is not None:
-            self.module.fail_json(
-                msg="droplet_ids and tag are mutually exclusive, please only define one of them"
-            )
-
         # Create it.
         request_params = dict(self.module.params)
         response = self.rest.post("load_balancers", data=request_params)
@@ -786,6 +780,12 @@ def main():
         required_if=(
             [
                 ("state", "present", ["forwarding_rules"]),
+            ]
+        ),
+        # Droplet ID and tag are mutually exclusive, check that both have not been defined
+        mutually_exclusive=(
+            [
+                ("tag", "droplet_ids"),
             ]
         ),
         supports_check_mode=True,

--- a/plugins/modules/digital_ocean_load_balancer.py
+++ b/plugins/modules/digital_ocean_load_balancer.py
@@ -67,8 +67,7 @@ options:
       - Required when creating load balancers.
       - Mutually exclusive with droplet_ids, you can either define tag or droplet_ids but not both.
     required: false
-    type: list
-    elements: int
+    type: str
   region:
     description:
       - The slug identifier for the region where the resource will initially be available.
@@ -609,10 +608,9 @@ class DOLoadBalancer(object):
 
         # Droplet ID and tag are mutually exclusive, check that both have not been defined
         if self.module.params.get('droplet_ids') is not None and self.module.params.get('tag') is not None:
-          self.module.fail_json(
+            self.module.fail_json(
                 msg="droplet_ids and tag are mutually exclusive, please only define one of them"
             )
-          
 
         # Create it.
         request_params = dict(self.module.params)

--- a/plugins/modules/digital_ocean_load_balancer.py
+++ b/plugins/modules/digital_ocean_load_balancer.py
@@ -738,7 +738,7 @@ def main():
                 default="round_robin",
             ),
             droplet_ids=dict(type="list", elements="int", required=False),
-            tag=dict(type=str, required=False),
+            tag=dict(type="str", required=False),
             region=dict(aliases=["region_id"], default="nyc1", required=False),
             forwarding_rules=dict(
                 type="list",
@@ -785,7 +785,7 @@ def main():
         ),
         required_if=(
             [
-                ("state", "present", ["droplet_ids", "forwarding_rules"], "tag"),
+                ("state", "present", ["forwarding_rules"]),
             ]
         ),
         supports_check_mode=True,

--- a/plugins/modules/digital_ocean_load_balancer.py
+++ b/plugins/modules/digital_ocean_load_balancer.py
@@ -788,6 +788,7 @@ def main():
                 ("tag", "droplet_ids"),
             ]
         ),
+        required_one_of=[("tag", "droplet_ids")],
         supports_check_mode=True,
     )
 

--- a/tests/integration/targets/digital_ocean_load_balancer/defaults/main.yml
+++ b/tests/integration/targets/digital_ocean_load_balancer/defaults/main.yml
@@ -5,3 +5,4 @@ droplet_size: s-1vcpu-1gb
 lb_name: gh-ci-loadbalancer
 lb_size: lb-small
 project_name: gh-ci-project
+lb_tag: test-tag

--- a/tests/integration/targets/digital_ocean_load_balancer/tasks/main.yml
+++ b/tests/integration/targets/digital_ocean_load_balancer/tasks/main.yml
@@ -160,6 +160,21 @@
       ansible.builtin.assert:
         that:
           - result.msg is search("mutually exclusive: tag|droplet_ids")
+  
+    - name: Create the Load Balancer (missing tag + droplet_ids)
+      community.digitalocean.digital_ocean_load_balancer:
+        oauth_token: "{{ do_api_key }}"
+        state: present
+        name: "{{ lb_name }}"
+        algorithm: round_robin
+        region: "{{ do_region }}"
+      ignore_errors: true  # Expected to fail
+      register: result
+
+    - name: Verify missing tag + droplet_ids fails
+      ansible.builtin.assert:
+        that:
+          - result.msg is search("required: tag, droplet_ids")
 
     - name: Create the Load Balancer (using tag)
       community.digitalocean.digital_ocean_load_balancer:

--- a/tests/integration/targets/digital_ocean_load_balancer/tasks/main.yml
+++ b/tests/integration/targets/digital_ocean_load_balancer/tasks/main.yml
@@ -130,6 +130,56 @@
           - lb.resources.status is defined
           - lb.resources.status == "assigned"
 
+    - name: Delete the Load Balancer
+      community.digitalocean.digital_ocean_load_balancer:
+        oauth_token: "{{ do_api_key }}"
+        state: absent
+        name: "{{ lb_name }}"
+        region: "{{ do_region }}"
+      register: result
+
+    - name: Verify Load Balancer is deleted
+      ansible.builtin.assert:
+        that:
+          - result.changed
+
+    - name: Create the Load Balancer (invalid tag + droplet_ids)
+      community.digitalocean.digital_ocean_load_balancer:
+        oauth_token: "{{ do_api_key }}"
+        state: present
+        name: "{{ lb_name }}"
+        algorithm: round_robin
+        droplet_ids:
+          - "{{ droplet.data.droplet.id }}"
+        tag: "{{ lb_tag }}"
+        region: "{{ do_region }}"
+      ignore_errors: true  # Expected to fail
+      register: result
+
+    - name: Verify invalid tag + droplet_ids fails
+      ansible.builtin.assert:
+        that:
+          - result.msg is search("mutually exclusive: tag|droplet_ids")
+
+    - name: Create the Load Balancer (using tag)
+      community.digitalocean.digital_ocean_load_balancer:
+        oauth_token: "{{ do_api_key }}"
+        state: present
+        name: "{{ lb_name }}"
+        algorithm: round_robin
+        tag: "{{ lb_tag }}"
+        region: "{{ do_region }}"
+      register: lb
+    
+    - name: Verify Load Balancer is present (from present)
+      ansible.builtin.assert:
+        that:
+          - lb.data is defined
+          - lb.data.load_balancer is defined
+          - lb.data.load_balancer.tag is defined
+          - lb.data.load_balancer.tag == lb_tag
+          - lb.data.load_balancer.status in ["new", "active", "available"]
+
   always:
 
     - name: Delete the Droplet

--- a/tests/integration/targets/digital_ocean_load_balancer/tasks/main.yml
+++ b/tests/integration/targets/digital_ocean_load_balancer/tasks/main.yml
@@ -174,7 +174,7 @@
     - name: Verify missing tag + droplet_ids fails
       ansible.builtin.assert:
         that:
-          - result.msg is search("required: tag, droplet_ids")
+          - result.msg is search("missing: tag, droplet_ids")
 
     - name: Create the Load Balancer (using tag)
       community.digitalocean.digital_ocean_load_balancer:


### PR DESCRIPTION
##### SUMMARY
Adding the ability to create a load balancer with a tag. Currently load balancers can only be created with a list of droplet IDs even though the API supports tags.

##### ISSUE TYPE

- Feature Pull Request
##### COMPONENT NAME

digital_ocean_load_balancer

##### ADDITIONAL INFORMATION

N/A
