### PR TITLE
Allow deleting droplet by id

### DIFF
--- a/changelogs/261-fix_deleting_by_id_only.yaml
+++ b/changelogs/261-fix_deleting_by_id_only.yaml
@@ -1,0 +1,6 @@
+bugfixes:
+  - digital_ocean_droplet - fix regression in droplet deletion where
+    ``name`` and ``unique_name`` (set to true) are required and ``id``
+    alone is insufficient (though ``id`` is sufficient to uniquely
+    identify a droplet for deletion).
+    (https://github.com/ansible-collections/community.digitalocean/issues/260)

--- a/plugins/modules/digital_ocean_droplet.py
+++ b/plugins/modules/digital_ocean_droplet.py
@@ -816,9 +816,13 @@ class DODroplet(object):
         self.module.exit_json(changed=True, data={"droplet": droplet})
 
     def delete(self):
-        if not self.unique_name:
+        # to delete a droplet we need to know the droplet id or unique name, ie
+        # name is not None and unique_name is True, but as "id or name" is
+        # enforced elsewhere, we only need to enforce "id or unique_name" here
+        if not self.module.params["id"] and not self.unique_name:
             self.module.fail_json(
-                changed=False, msg="unique_name must be set for deletes"
+                changed=False,
+                msg="id must be set or unique_name must be true for deletes",
             )
         json_data = self.get_droplet()
         if json_data is None:
@@ -903,7 +907,6 @@ def main():
                 ("state", "present", ["name", "size", "image", "region"]),
                 ("state", "active", ["name", "size", "image", "region"]),
                 ("state", "inactive", ["name", "size", "image", "region"]),
-                ("state", "absent", ["name", "unique_name"]),
             ]
         ),
         supports_check_mode=True,

--- a/tests/integration/targets/digital_ocean_droplet/tasks/main.yml
+++ b/tests/integration/targets/digital_ocean_droplet/tasks/main.yml
@@ -116,17 +116,20 @@
           - result.msg is search("Assigned")
           - result.msg is search("to project " ~ secondary_project_name)
 
-    - name: Destroy the Droplet (absent)
+    - name: Destroy the Droplet (absent, by ID only)
       community.digitalocean.digital_ocean_droplet:
         oauth_token: "{{ do_api_key }}"
         state: absent
-        name: "{{ droplet_name }}"
         id: "{{ result.data.droplet.id }}"
-        unique_name: true
         region: "{{ do_region }}"
         image: "{{ droplet_image }}"
         size: "{{ droplet_size }}"
       register: result
+
+    - name: Verify Droplet is absent (from absent, by ID only)
+      ansible.builtin.assert:
+        that:
+          - result.changed
 
     - name: Give the cloud a minute to settle
       ansible.builtin.pause:
@@ -155,18 +158,19 @@
           - result.msg is search("Assigned")
           - result.msg is search("to project " ~ secondary_project_name)
 
-    - name: Destroy the Droplet (absent)
+    - name: Destroy the Droplet (absent, by unique name and ID)
       community.digitalocean.digital_ocean_droplet:
         oauth_token: "{{ do_api_key }}"
         state: absent
         name: "{{ droplet_name }}"
         unique_name: true
+        id: "{{ result.data.droplet.id }}"
         region: "{{ do_region }}"
         image: "{{ droplet_image }}"
         size: "{{ droplet_size }}"
       register: result
 
-    - name: Verify Droplet is absent (from absent)
+    - name: Verify Droplet is absent (from absent, by unique name and ID)
       ansible.builtin.assert:
         that:
           - result.changed
@@ -213,7 +217,7 @@
           - result.data.droplet.name == droplet_name
           - result.data.droplet.status in ["new", "active", "available"]
 
-    - name: Destroy the Droplet (absent)
+    - name: Destroy the Droplet (absent, by unique name only)
       community.digitalocean.digital_ocean_droplet:
         oauth_token: "{{ do_api_key }}"
         state: absent
@@ -224,7 +228,7 @@
         size: "{{ droplet_size }}"
       register: result
 
-    - name: Verify Droplet is absent (from absent)
+    - name: Verify Droplet is absent (from absent, by unique name only)
       ansible.builtin.assert:
         that:
           - result.changed


### PR DESCRIPTION
##### SUMMARY
For droplet deletion, #184 required `name` and `unique_name` and
verified `unique_name` is true, to the exclusion of `id`.

Remove requirement from `required_if` as it cannot enforce the logic
`id or (name and unique_name)` and modify the verification of
`unique_name` to include `id` (and don't worry about `name` because
either it or `id` are already required elsewhere).

Fixes #260.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
digital_ocean_droplet
