### PR TITLE
Get updated droplet by id during create wait

### DIFF
--- a/changelogs/fragments/265-get_updated_droplet_info_on_create_wait_by_id.yaml
+++ b/changelogs/fragments/265-get_updated_droplet_info_on_create_wait_by_id.yaml
@@ -1,0 +1,5 @@
+bugfixes:
+  - digital_ocean_droplet - fix regression where droplet info (for example
+    networking) doesn't update when waiting during creation unless
+    ``unique_name`` is set to true
+    (https://github.com/ansible-collections/community.digitalocean/issues/220).

--- a/plugins/modules/digital_ocean_droplet.py
+++ b/plugins/modules/digital_ocean_droplet.py
@@ -776,8 +776,7 @@ class DODroplet(object):
 
         # Get updated Droplet data (fallback to current data)
         if self.wait:
-            json_data = self.get_droplet()
-            # Without unique_name json_data is None
+            json_data = self.get_by_id(droplet_id)
             if json_data:
                 droplet = json_data.get("droplet", droplet)
 

--- a/tests/integration/targets/digital_ocean_droplet/tasks/main.yml
+++ b/tests/integration/targets/digital_ocean_droplet/tasks/main.yml
@@ -115,6 +115,8 @@
           - result.assign_status == "assigned"
           - result.msg is search("Assigned")
           - result.msg is search("to project " ~ secondary_project_name)
+          # issue #220: droplet.networks.v4 is empty when unique_name != true
+          - result.data.droplet.networks.v4 != []
 
     - name: Destroy the Droplet (absent)
       community.digitalocean.digital_ocean_droplet:


### PR DESCRIPTION
##### SUMMARY
When updating droplet info while waiting after creation, instead of
using `get_droplet()` and being dependent upon the optional
`unique_name` feature, use `get_by_id()` with the droplet's ID which
we should have having just created the droplet.

Fixes #220.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
digital_ocean_droplet
