### PR TITLE
Don't throw an exception if API's JSON response lacks an expected key

### DIFF
--- a/changelogs/fragments/273-Dont_call_get_on_None.yaml
+++ b/changelogs/fragments/273-Dont_call_get_on_None.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - digital_ocean_droplet - if the JSON response lacks a key and the associated variable is set to ``None``, then don't treat that variable like a ``dict`` and call ``get()`` on it without first testing it (https://github.com/ansible-collections/community.digitalocean/issues/272).

--- a/plugins/modules/digital_ocean_droplet.py
+++ b/plugins/modules/digital_ocean_droplet.py
@@ -542,7 +542,7 @@ class DODroplet(object):
             status_code = response.status_code
             message = json_data.get("message", "no error message")
             droplet = json_data.get("droplet", None)
-            droplet_status = droplet.get("status", None)
+            droplet_status = droplet.get("status", None) if droplet else None
 
             if droplet is None or droplet_status is None:
                 self.module.fail_json(


### PR DESCRIPTION
##### SUMMARY
Instead of throwing an exception, be more defensive in the code: if
the API's JSON response lacks a key and we correspondingly set a
variable to `None`, then don't call `get()` on the variable, but test
the variable first.

    AttributeError: 'NoneType' object has no attribute 'get'

Fixes #272.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
digital_ocean_droplet

##### ADDITIONAL INFORMATION
```
AttributeError: 'NoneType' object has no attribute 'get'
```
