### PR TITLE
Release 1.21.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,19 @@ Community DigitalOcean Release Notes
 .. contents:: Topics
 
 
+v1.21.0
+=======
+
+Minor Changes
+-------------
+
+- digital_ocean - add sanity test ignores for Ansible 2.12 and 2.13 (https://github.com/ansible-collections/community.digitalocean/issues/247).
+
+Bugfixes
+--------
+
+- digital_ocean_droplet - if the JSON response lacks a key and the associated variable is set to ``None``, then don't treat that variable like a ``dict`` and call ``get()`` on it without first testing it (https://github.com/ansible-collections/community.digitalocean/issues/272).
+
 v1.20.0
 =======
 
@@ -12,7 +25,7 @@ Minor Changes
 -------------
 
 - digital_ocean_cdn_endpoints - update Spaces endpoint and add a few delays to the integration test (https://github.com/ansible-collections/community.digitalocean/issues/267).
-- digital_ocean_load_balancer - allow creating a load balancer and associating droplets by tag as an alternative to ``droplet_ids`` (https://github.com/ansible-collections/community.digitalocean/issues/270).
+- digital_ocean_load_balancer - Allow creating a load balancer and associating droplets by tag as an alternative to ``droplet_ids``.
 
 Bugfixes
 --------

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -308,6 +308,18 @@ releases:
     - 265-get_updated_droplet_info_on_create_wait_by_id.yaml
     - 267-update-cdn-endpoints.yaml
     release_date: '2022-06-10'
+  1.21.0:
+    changes:
+      bugfixes:
+      - digital_ocean_droplet - if the JSON response lacks a key and the associated
+        variable is set to ``None``, then don't treat that variable like a ``dict``
+        and call ``get()`` on it without first testing it (https://github.com/ansible-collections/community.digitalocean/issues/272).
+      minor_changes:
+      - digital_ocean - add sanity test ignores for Ansible 2.12 and 2.13 (https://github.com/ansible-collections/community.digitalocean/issues/247).
+    fragments:
+    - 247-sanity-checks-2.12-13.yaml
+    - 273-Dont_call_get_on_None.yaml
+    release_date: '2022-06-29'
   1.3.0:
     modules:
     - description: Create and delete a DigitalOcean database

--- a/changelogs/fragments/247-sanity-checks-2.12-13.yaml
+++ b/changelogs/fragments/247-sanity-checks-2.12-13.yaml
@@ -1,2 +1,0 @@
-minor_changes:
-  - digital_ocean - add sanity test ignores for Ansible 2.12 and 2.13 (https://github.com/ansible-collections/community.digitalocean/issues/247).

--- a/changelogs/fragments/273-Dont_call_get_on_None.yaml
+++ b/changelogs/fragments/273-Dont_call_get_on_None.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - digital_ocean_droplet - if the JSON response lacks a key and the associated variable is set to ``None``, then don't treat that variable like a ``dict`` and call ``get()`` on it without first testing it (https://github.com/ansible-collections/community.digitalocean/issues/272).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -43,7 +43,7 @@ tags:
   - digitalocean
   - cloud
   - droplet
-version: 1.20.0
+version: 1.21.0
 build_ignore:
   - .DS_Store
   - '*.tar.gz'


### PR DESCRIPTION
* Small bugfix to `digital_ocean_droplet`
* Add sanity test ignores for Ansible 2.12 and 2.13