### PR TITLE
Update `digital_ocean_load_balancer` (for `size_unit`)

### DIFF
--- a/changelogs/fragments/270-load-balancer-size-unit.yaml
+++ b/changelogs/fragments/270-load-balancer-size-unit.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - digital_ocean_load_balancer - add support for C(size_unit) over deprecated C(size); deprecate C(algorithm) completely (https://github.com/ansible-collections/community.digitalocean/issues/270).

--- a/plugins/doc_fragments/digital_ocean.py
+++ b/plugins/doc_fragments/digital_ocean.py
@@ -20,9 +20,9 @@ options:
     default: https://api.digitalocean.com/v2
   oauth_token:
     description:
-     - DigitalOcean OAuth token.
-     - "There are several other environment variables which can be used to provide this value."
-     - "i.e., - 'DO_API_TOKEN', 'DO_API_KEY', 'DO_OAUTH_TOKEN' and 'OAUTH_TOKEN'"
+      - DigitalOcean OAuth token.
+      - "There are several other environment variables which can be used to provide this value."
+      - "i.e., - 'DO_API_TOKEN', 'DO_API_KEY', 'DO_OAUTH_TOKEN' and 'OAUTH_TOKEN'"
     type: str
     aliases: [ api_token ]
   timeout:

--- a/tests/integration/targets/digital_ocean_load_balancer/tasks/main.yml
+++ b/tests/integration/targets/digital_ocean_load_balancer/tasks/main.yml
@@ -54,7 +54,6 @@
         oauth_token: "{{ do_api_key }}"
         state: present
         name: "{{ lb_name }}"
-        algorithm: round_robin
         droplet_ids:
           - "{{ droplet.data.droplet.id }}"
         region: "{{ do_region }}"
@@ -69,24 +68,6 @@
           - lb.data.load_balancer.name is defined
           - lb.data.load_balancer.name == lb_name
           - lb.data.load_balancer.status in ["new", "active", "available"]
-
-    - name: Change the Load Balancer (algorithm)
-      community.digitalocean.digital_ocean_load_balancer:
-        oauth_token: "{{ do_api_key }}"
-        state: present
-        name: "{{ lb_name }}"
-        algorithm: least_connections
-        droplet_ids:
-          - "{{ droplet.data.droplet.id }}"
-        region: "{{ do_region }}"
-      register: lb
-
-    - name: Verify Load Balancer is changed
-      ansible.builtin.assert:
-        that:
-          - lb.changed is true
-          - lb.failed is false
-          - "'updated: algorithm' in lb.msg"
 
     - name: Delete the Load Balancer
       community.digitalocean.digital_ocean_load_balancer:
@@ -106,7 +87,6 @@
         oauth_token: "{{ do_api_key }}"
         state: present
         name: "{{ lb_name }}"
-        algorithm: round_robin
         droplet_ids:
           - "{{ droplet.data.droplet.id }}"
         region: "{{ do_region }}"
@@ -148,7 +128,6 @@
         oauth_token: "{{ do_api_key }}"
         state: present
         name: "{{ lb_name }}"
-        algorithm: round_robin
         droplet_ids:
           - "{{ droplet.data.droplet.id }}"
         tag: "{{ lb_tag }}"
@@ -160,13 +139,12 @@
       ansible.builtin.assert:
         that:
           - result.msg is search("mutually exclusive: tag|droplet_ids")
-  
+
     - name: Create the Load Balancer (missing tag + droplet_ids)
       community.digitalocean.digital_ocean_load_balancer:
         oauth_token: "{{ do_api_key }}"
         state: present
         name: "{{ lb_name }}"
-        algorithm: round_robin
         region: "{{ do_region }}"
       ignore_errors: true  # Expected to fail
       register: result
@@ -181,11 +159,10 @@
         oauth_token: "{{ do_api_key }}"
         state: present
         name: "{{ lb_name }}"
-        algorithm: round_robin
         tag: "{{ lb_tag }}"
         region: "{{ do_region }}"
       register: lb
-    
+
     - name: Verify Load Balancer is present (from present)
       ansible.builtin.assert:
         that:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add support for `size_unit` (versus `size`); deprecate `algorithm` -- fixes #270.
This field has been replaced by the `size_unit` field for all regions except in AMS2, NYC2, and SFO1.
The formula is lb-small = 1 node, lb-medium = 3 nodes, lb-large = 6 nodes.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

- `digital_ocean_load_balancer`

