### PR TITLE
Add an action_group to default vars for every module

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ It's preferable to use content in this collection using their Fully Qualified Co
   vars:
     oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
 
+  # You can also default the value of a variable for every DO module using module_defaults
+  # module_defaults:
+  #   group/community.digitalocean.all:
+  #     oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
+
   tasks:
     - name: Create SSH key
       community.digitalocean.digital_ocean_sshkey:

--- a/changelogs/fragments/281-default-all-action-group.yml
+++ b/changelogs/fragments/281-default-all-action-group.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "collection - added an action group 'community.digitalocean.all' for use with module defaults: https://docs.ansible.com/ansible/latest/user_guide/playbooks_module_defaults.html (https://github.com/ansible-collections/community.digitalocean/issues/281)"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,4 +1,61 @@
 requires_ansible: '>=2.9.10'
+action_groups:
+  all:
+    - digital_ocean
+    - digital_ocean_account_facts
+    - digital_ocean_account_info
+    - digital_ocean_balance_info
+    - digital_ocean_block_storage
+    - digital_ocean_cdn_endpoints_info
+    - digital_ocean_cdn_endpoints
+    - digital_ocean_certificate
+    - digital_ocean_certificate_facts
+    - digital_ocean_certificate_info
+    - digital_ocean_database_info
+    - digital_ocean_database
+    - digital_ocean_domain
+    - digital_ocean_domain_facts
+    - digital_ocean_domain_info
+    - digital_ocean_domain_record_info
+    - digital_ocean_domain_record
+    - digital_ocean_droplet
+    - digital_ocean_droplet_info
+    - digital_ocean_firewall
+    - digital_ocean_firewall_facts
+    - digital_ocean_firewall_info
+    - digital_ocean_floating_ip
+    - digital_ocean_floating_ip_facts
+    - digital_ocean_floating_ip_info
+    - digital_ocean_image_facts
+    - digital_ocean_image_info
+    - digital_ocean_kubernetes_info
+    - digital_ocean_kubernetes
+    - digital_ocean_load_balancer
+    - digital_ocean_load_balancer_facts
+    - digital_ocean_load_balancer_info
+    - digital_ocean_monitoring_alerts
+    - digital_ocean_monitoring_alerts_info
+    - digital_ocean_project_info
+    - digital_ocean_project
+    - digital_ocean_region_facts
+    - digital_ocean_region_info
+    - digital_ocean_size_facts
+    - digital_ocean_size_info
+    - digital_ocean_snapshot_facts
+    - digital_ocean_snapshot_info
+    - digital_ocean_snapshot
+    - digital_ocean_spaces_info
+    - digital_ocean_spaces
+    - digital_ocean_sshkey
+    - digital_ocean_sshkey_facts
+    - digital_ocean_sshkey_info
+    - digital_ocean_tag
+    - digital_ocean_tag_facts
+    - digital_ocean_tag_info
+    - digital_ocean_volume_facts
+    - digital_ocean_volume_info
+    - digital_ocean_vpc
+    - digital_ocean_vpc_info
 plugin_routing:
   modules:
     digital_ocean:


### PR DESCRIPTION
##### SUMMARY

Add an action_group to default vars for every module

This allows, for example, to default the value of oauth_token once
without needing to specify it in every task unless it needs to be
overridden.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

meta/runtime.yml

##### ADDITIONAL INFORMATION

Inspired by azure.azcollection's recent fix: https://github.com/ansible-collections/azure/pull/874

Edit: it looks like this for the example in the README:

![Screenshot from 2022-08-17 23-26-56](https://user-images.githubusercontent.com/1291204/185286523-5b24c073-783d-4b90-9d6f-43124481585c.png)