### PR TITLE
Release 1.22.0

### DIFF
--- a/.github/workflows/pull-request-integration.yml
+++ b/.github/workflows/pull-request-integration.yml
@@ -55,8 +55,50 @@ jobs:
     if: ${{ needs.changes.outputs.module-utils-matrix != '[""]' }}
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
-        module: ${{ fromJSON(needs.changes.outputs.module-matrix) }}
+        module:
+          - digital_ocean_account_info
+          - digital_ocean_balance_info
+          - digital_ocean_block_storage
+          - digital_ocean_cdn_endpoints
+          - digital_ocean_cdn_endpoints_info
+          - digital_ocean_certificate
+          - digital_ocean_certificate_info
+          - digital_ocean_database
+          - digital_ocean_database_info
+          - digital_ocean_domain
+          - digital_ocean_domain_info
+          - digital_ocean_domain_record
+          - digital_ocean_domain_record_info
+          - digital_ocean_droplet
+          - digital_ocean_droplet_info
+          - digital_ocean_firewall
+          - digital_ocean_firewall_info
+          - digital_ocean_floating_ip
+          - digital_ocean_floating_ip_info
+          - digital_ocean_image_info
+          - digital_ocean_kubernetes
+          - digital_ocean_kubernetes_info
+          - digital_ocean_load_balancer
+          - digital_ocean_load_balancer_info
+          - digital_ocean_monitoring_alerts
+          - digital_ocean_monitoring_alerts_info
+          - digital_ocean_project
+          - digital_ocean_project_info
+          - digital_ocean_region_info
+          - digital_ocean_size_info
+          - digital_ocean_snapshot
+          - digital_ocean_snapshot_info
+          - digital_ocean_spaces
+          - digital_ocean_spaces_info
+          - digital_ocean_sshkey
+          - digital_ocean_sshkey_info
+          - digital_ocean_tag
+          - digital_ocean_tag_info
+          - digital_ocean_volume_info
+          - digital_ocean_vpc
+          - digital_ocean_vpc_info
     steps:
       - name: Perform testing (all modules)
         uses: ansible-community/ansible-test-gh-action@release/v1
@@ -69,10 +111,11 @@ jobs:
             ./tests/utils/render.sh
             tests/integration/integration_config.yml.template
             > tests/integration/integration_config.yml
-          output-python-version: 3.9
+          origin-python-version: 3.9
           target-python-version: 3.9
           testing-type: integration
           test-deps: community.general
+          target: ${{ matrix.module }}
 
   test-modules:
     runs-on: ubuntu-latest
@@ -95,7 +138,7 @@ jobs:
             ./tests/utils/render.sh
             tests/integration/integration_config.yml.template
             > tests/integration/integration_config.yml
-          output-python-version: 3.9
+          origin-python-version: 3.9
           target-python-version: 3.9
           testing-type: integration
           test-deps: community.general

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,15 @@ Community DigitalOcean Release Notes
 .. contents:: Topics
 
 
+v1.22.0
+=======
+
+Minor Changes
+-------------
+
+- collection - added an action group 'community.digitalocean.all' for use with module defaults: https://docs.ansible.com/ansible/latest/user_guide/playbooks_module_defaults.html (https://github.com/ansible-collections/community.digitalocean/issues/281).
+- digital_ocean_vpc - add C(vpc) key to returned VPC data on create (https://github.com/ansible-collections/community.digitalocean/issues/276).
+
 v1.21.0
 =======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,8 +11,10 @@ v1.22.0
 Minor Changes
 -------------
 
-- collection - added an action group 'community.digitalocean.all' for use with module defaults: https://docs.ansible.com/ansible/latest/user_guide/playbooks_module_defaults.html (https://github.com/ansible-collections/community.digitalocean/issues/281).
+- collection - added an action group C(community.digitalocean.all) for use with module defaults (https://docs.ansible.com/ansible/latest/user_guide/playbooks_module_defaults.html) (https://github.com/ansible-collections/community.digitalocean/issues/281).
 - digital_ocean_vpc - add C(vpc) key to returned VPC data on create (https://github.com/ansible-collections/community.digitalocean/issues/276).
+- integration tests - perform integration testing on all modules for changes in C(plugins/module_utils) or by changed module in C(plugins/modules) (https://github.com/ansible-collections/community.digitalocean/issues/286).
+- integration tests - split the integration tests by module and run them serially (https://github.com/ansible-collections/community.digitalocean/issues/280).
 
 v1.21.0
 =======

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -320,6 +320,17 @@ releases:
     - 247-sanity-checks-2.12-13.yaml
     - 273-Dont_call_get_on_None.yaml
     release_date: '2022-06-29'
+  1.22.0:
+    changes:
+      minor_changes:
+      - 'collection - added an action group ''community.digitalocean.all'' for use
+        with module defaults: https://docs.ansible.com/ansible/latest/user_guide/playbooks_module_defaults.html
+        (https://github.com/ansible-collections/community.digitalocean/issues/281)'.
+      - digital_ocean_vpc - add C(vpc) key to returned VPC data on create (https://github.com/ansible-collections/community.digitalocean/issues/276).
+    fragments:
+    - 276-vpc-inconsistent-data-return.yml
+    - 281-default-all-action-group.yml
+    release_date: '2022-09-24'
   1.3.0:
     modules:
     - description: Create and delete a DigitalOcean database

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -323,14 +323,19 @@ releases:
   1.22.0:
     changes:
       minor_changes:
-      - 'collection - added an action group ''community.digitalocean.all'' for use
-        with module defaults: https://docs.ansible.com/ansible/latest/user_guide/playbooks_module_defaults.html
-        (https://github.com/ansible-collections/community.digitalocean/issues/281)'.
+      - collection - added an action group C(community.digitalocean.all) for use with
+        module defaults (https://docs.ansible.com/ansible/latest/user_guide/playbooks_module_defaults.html)
+        (https://github.com/ansible-collections/community.digitalocean/issues/281).
       - digital_ocean_vpc - add C(vpc) key to returned VPC data on create (https://github.com/ansible-collections/community.digitalocean/issues/276).
+      - integration tests - perform integration testing on all modules for changes
+        in C(plugins/module_utils) or by changed module in C(plugins/modules) (https://github.com/ansible-collections/community.digitalocean/issues/286).
+      - integration tests - split the integration tests by module and run them serially
+        (https://github.com/ansible-collections/community.digitalocean/issues/280).
     fragments:
     - 276-vpc-inconsistent-data-return.yml
     - 281-default-all-action-group.yml
-    release_date: '2022-09-24'
+    - 286-refactor-pr-integration-testing.yaml
+    release_date: '2022-10-03'
   1.3.0:
     modules:
     - description: Create and delete a DigitalOcean database

--- a/changelogs/fragments/276-vpc-inconsistent-data-return.yml
+++ b/changelogs/fragments/276-vpc-inconsistent-data-return.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - digital_ocean_vpc - add C(vpc) key to returned VPC data on create (https://github.com/ansible-collections/community.digitalocean/issues/276).

--- a/changelogs/fragments/281-default-all-action-group.yml
+++ b/changelogs/fragments/281-default-all-action-group.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - "collection - added an action group 'community.digitalocean.all' for use with module defaults: https://docs.ansible.com/ansible/latest/user_guide/playbooks_module_defaults.html (https://github.com/ansible-collections/community.digitalocean/issues/281)"

--- a/changelogs/fragments/286-refactor-pr-integration-testing.yaml
+++ b/changelogs/fragments/286-refactor-pr-integration-testing.yaml
@@ -1,2 +1,0 @@
-minor_changes:
-  - integration tests - perform integration testing on all modules for changes in C(plugins/module_utils) or by changed module in C(plugins/modules) (https://github.com/ansible-collections/community.digitalocean/issues/286).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -43,7 +43,7 @@ tags:
   - digitalocean
   - cloud
   - droplet
-version: 1.21.0
+version: 1.22.0
 build_ignore:
   - .DS_Store
   - '*.tar.gz'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Release 1.22.0; minor changes in the collection: adding action group `community.digitalocean.all` and adding `vpc` key to data returned in `digital_ocean_vpc`. Refactoring integration testing so that the daily runs are split by module and integration test pull requests either happen for all modules (for changes under `module_utils`) or on the affected modules (for changes under `modules`).
