### PR TITLE
droplet: Allow creating droplet without droplet agent

### DIFF
--- a/plugins/modules/digital_ocean_droplet.py
+++ b/plugins/modules/digital_ocean_droplet.py
@@ -121,6 +121,14 @@ options:
     required: false
     default: false
     type: bool
+  with_droplet_agent:
+    description:
+      - Indicates whether to install the DigitalOcean agent used for providing access to the Droplet web console in the control panel.
+      - By default, the agent is installed on new Droplets but installation errors (i.e. OS not supported) are ignored.
+      - To prevent it from being installed, set to C(false).
+      - To make installation errors fatal, explicitly set it to C(true).
+    required: false
+    type: bool
   tags:
     description:
       - A list of tag names as strings to apply to the Droplet after it is created.
@@ -885,6 +893,7 @@ def main():
         vpc_uuid=dict(type="str"),
         backups=dict(type="bool", default=False),
         monitoring=dict(type="bool", default=False),
+        with_droplet_agent=dict(type="bool"),
         id=dict(aliases=["droplet_id"], type="int"),
         user_data=dict(default=None),
         ipv6=dict(type="bool", default=False),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Allow passing `with_droplet_agent` boolean argument to droplet create API request to explicitly install or not the droplet agent which facilitates connecting to the droplet using the web console in the control panel.  The API default is to install the droplet agent.  This option allows a user to request not installing the droplet agent.

https://docs.digitalocean.com/reference/api/api-reference/#operation/droplets_create

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
<!-- - Bugfix Pull Request -->
<!-- - Docs Pull Request -->
- Feature Pull Request
<!-- - New Module Pull Request -->

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
digital_ocean_droplet

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
