### PR TITLE
Split integration testing by module

### DIFF
--- a/.github/workflows/ansible-test-integration.yml
+++ b/.github/workflows/ansible-test-integration.yml
@@ -76,7 +76,7 @@ jobs:
             ./tests/utils/render.sh
             tests/integration/integration_config.yml.template
             > tests/integration/integration_config.yml
-          python-version: 3.9
+          origin-python-version: 3.9
           target: ${{ matrix.module }}
           target-python-version: 3.9
           testing-type: integration

--- a/.github/workflows/ansible-test-integration.yml
+++ b/.github/workflows/ansible-test-integration.yml
@@ -19,9 +19,50 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         module:
           - digital_ocean_account_info
+          - digital_ocean_balance_info
+          - digital_ocean_block_storage
+          - digital_ocean_cdn_endpoints
+          - digital_ocean_cdn_endpoints_info
+          - digital_ocean_certificate
+          - digital_ocean_certificate_info
+          - digital_ocean_database
+          - digital_ocean_database_info
+          - digital_ocean_domain
+          - digital_ocean_domain_info
+          - digital_ocean_domain_record
+          - digital_ocean_domain_record_info
+          - digital_ocean_droplet
+          - digital_ocean_droplet_info
+          - digital_ocean_firewall
+          - digital_ocean_firewall_info
+          - digital_ocean_floating_ip
+          - digital_ocean_floating_ip_info
+          - digital_ocean_image_info
+          - digital_ocean_kubernetes
+          - digital_ocean_kubernetes_info
+          - digital_ocean_load_balancer
+          - digital_ocean_load_balancer_info
+          - digital_ocean_monitoring_alerts
+          - digital_ocean_monitoring_alerts_info
+          - digital_ocean_project
+          - digital_ocean_project_info
+          - digital_ocean_region_info
+          - digital_ocean_size_info
+          - digital_ocean_snapshot
+          - digital_ocean_snapshot_info
+          - digital_ocean_spaces
+          - digital_ocean_spaces_info
+          - digital_ocean_sshkey
+          - digital_ocean_sshkey_info
+          - digital_ocean_tag
+          - digital_ocean_tag_info
+          - digital_ocean_volume_info
+          - digital_ocean_vpc
+          - digital_ocean_vpc_info
     timeout-minutes: 120
 
     steps:

--- a/.github/workflows/ansible-test-integration.yml
+++ b/.github/workflows/ansible-test-integration.yml
@@ -4,29 +4,31 @@ on:
   # pull_request:
   push:
     branches:
-      - ci*
-      - main
-  schedule:
-    - cron: '10 6 * * *'
+      # - ci*
+      # - main
+      - mamercad/issue-280
+  # schedule:
+  #   - cron: "10 6 * * *"
 
 concurrency:
   group: cloud-integration-tests
   cancel-in-progress: false
 
 jobs:
-
   integration:
-
     runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: false
+      matrix:
+        module:
+          - digital_ocean_account_info
     timeout-minutes: 120
 
     steps:
       - name: Perform testing
         uses: ansible-community/ansible-test-gh-action@release/v1
         with:
-          # ansible-core-version:
-          pre-test-cmd: >-  # Configure integration test run
+          pre-test-cmd: >-
             DO_API_KEY=${{ secrets.DO_API_KEY }}
             AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -34,6 +36,7 @@ jobs:
             tests/integration/integration_config.yml.template
             > tests/integration/integration_config.yml
           python-version: 3.9
+          target: ${{ matrix.module }}
           target-python-version: 3.9
           testing-type: integration
           test-deps: community.general

--- a/.github/workflows/ansible-test-integration.yml
+++ b/.github/workflows/ansible-test-integration.yml
@@ -1,14 +1,10 @@
 name: integration
 on:
-  # ! Don't enable pwn requests !
-  # pull_request:
   push:
     branches:
-      # - ci*
-      # - main
-      - mamercad/issue-280
-  # schedule:
-  #   - cron: "10 6 * * *"
+      - main
+  schedule:
+    - cron: "10 6 * * *"
 
 concurrency:
   group: cloud-integration-tests

--- a/.github/workflows/ansible-test-integration.yml
+++ b/.github/workflows/ansible-test-integration.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   integration:
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -63,7 +64,6 @@ jobs:
           - digital_ocean_volume_info
           - digital_ocean_vpc
           - digital_ocean_vpc_info
-    timeout-minutes: 120
 
     steps:
       - name: Perform testing


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Split the integration tests by module and run them serially. With as many modules as there are in this collection, going through the output when integration tests fail has become too daunting. [Here's](https://github.com/ansible-collections/community.digitalocean/actions/runs/3119044015) an example of how this will behave.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

* integration tests

