### PR TITLE
Split integration testing by module (on pull request)

### DIFF
--- a/.github/workflows/ansible-test-integration.yml
+++ b/.github/workflows/ansible-test-integration.yml
@@ -5,6 +5,7 @@ on:
       - main
   schedule:
     - cron: "10 6 * * *"
+  workflow_dispatch:
 
 concurrency:
   group: cloud-integration-tests

--- a/.github/workflows/pull-request-integration.yml
+++ b/.github/workflows/pull-request-integration.yml
@@ -2,38 +2,101 @@ name: pull-request-integration
 
 on:
   pull_request_target:
-    branches: [ main ]
-    types: [ opened, synchronize, reopened ]
+    branches: [main]
+    types: [opened, synchronize, reopened]
+    paths:
+      - plugins/module_utils/**
+      - plugins/modules/**
 
 concurrency:
   group: cloud-integration-tests
   cancel-in-progress: false
 
-jobs:
+env:
+  DEFAULT_BRANCH: remotes/origin/main
 
-  integration:
+jobs:
+  changes:
     # Require reviewers for this environment
     # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
     environment: integration
-
     runs-on: ubuntu-latest
-
-    timeout-minutes: 120
-
     steps:
-      - name: Perform testing
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: get changed module_utils
+        id: changed-module-utils
+        run: |
+          basenames=()
+          for file in $(git diff --name-only $DEFAULT_BRANCH | grep 'plugins/module_utils/'); do
+            basenames+=($(basename $file .py))
+          done
+          printf '::set-output name=matrix::%s\n' $(printf '%s\n' "${basenames[@]}" | jq -R . | jq -sc .)
+
+      - name: get changed modules
+        id: changed-modules
+        run: |
+          basenames=()
+          for file in $(git diff --name-only $DEFAULT_BRANCH | grep 'plugins/modules/'); do
+            basenames+=($(basename $file .py))
+          done
+          printf '::set-output name=matrix::%s\n' $(printf '%s\n' "${basenames[@]}" | jq -R . | jq -sc .)
+
+    outputs:
+      module-utils-matrix: ${{ steps.changed-module-utils.outputs.matrix }}
+      module-matrix: ${{ steps.changed-modules.outputs.matrix }}
+
+  test-module-utils:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    needs: [changes]
+    if: ${{ needs.changes.outputs.module-utils-matrix != '[""]' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        module: ${{ fromJSON(needs.changes.outputs.module-matrix) }}
+    steps:
+      - name: Perform testing (all modules)
         uses: ansible-community/ansible-test-gh-action@release/v1
         with:
-          # ansible-core-version:
-          git-checkout-ref: ${{ github.event.pull_request.head.sha }} # Check out the pull request
-          pre-test-cmd: >-  # Configure integration test run
+          git-checkout-ref: ${{ github.event.pull_request.head.sha }}
+          pre-test-cmd: >-
             DO_API_KEY=${{ secrets.DO_API_KEY }}
             AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
             ./tests/utils/render.sh
             tests/integration/integration_config.yml.template
             > tests/integration/integration_config.yml
-          python-version: 3.9
+          output-python-version: 3.9
           target-python-version: 3.9
           testing-type: integration
           test-deps: community.general
+
+  test-modules:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    needs: [changes]
+    if: ${{ needs.changes.outputs.module-utils-matrix == '[""]' && needs.changes.outputs.module-matrix != '[""]' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        module: ${{ fromJSON(needs.changes.outputs.module-matrix) }}
+    steps:
+      - name: Perform testing (changed module)
+        uses: ansible-community/ansible-test-gh-action@release/v1
+        with:
+          git-checkout-ref: ${{ github.event.pull_request.head.sha }}
+          pre-test-cmd: >-
+            DO_API_KEY=${{ secrets.DO_API_KEY }}
+            AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            ./tests/utils/render.sh
+            tests/integration/integration_config.yml.template
+            > tests/integration/integration_config.yml
+          output-python-version: 3.9
+          target-python-version: 3.9
+          testing-type: integration
+          test-deps: community.general
+          target: ${{ matrix.module }}

--- a/changelogs/fragments/286-refactor-pr-integration-testing.yaml
+++ b/changelogs/fragments/286-refactor-pr-integration-testing.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - integration tests - perform integration testing on all modules for changes in C(plugins/module_utils) or by changed module in C(plugins/modules) (https://github.com/ansible-collections/community.digitalocean/issues/286).


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixed #286. Currently, integration testing on pull requests runs the entire battery of integration tests. While thorough, it's not necessary. In the case where module_utils change, run all of the integration tests. In the case where modules are changed, just run the integration tests for those modules.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- CI enhancement

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- Integration tests

