### PR TITLE
Inventory plugin: drop `api_token` in favor of `oauth_token`

### DIFF
--- a/changelogs/fragments/300-inventory-plugin-oauth-token.yaml
+++ b/changelogs/fragments/300-inventory-plugin-oauth-token.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - inventory plugin - drop C(api_token) in favor of C(oauth_token) for consistency (https://github.com/ansible-collections/community.digitalocean/issues/300).

--- a/plugins/inventory/digitalocean.py
+++ b/plugins/inventory/digitalocean.py
@@ -30,15 +30,6 @@ options:
         this should always be C(community.digitalocean.digitalocean).
     required: true
     choices: ['community.digitalocean.digitalocean']
-  api_token:
-    description:
-     - DigitalOcean OAuth token.
-     - Template expressions can be used in this field.
-    required: true
-    type: str
-    aliases: [ oauth_token ]
-    env:
-      - name: DO_API_TOKEN
   attributes:
     description: >-
       Droplet attributes to add as host vars to each inventory host.
@@ -78,7 +69,7 @@ options:
 EXAMPLES = r"""
 # Using keyed groups and compose for hostvars
 plugin: community.digitalocean.digitalocean
-api_token: '{{ lookup("pipe", "./get-do-token.sh" }}'
+oauth_token: '{{ lookup("pipe", "./get-do-token.sh" }}'
 attributes:
   - id
   - name
@@ -108,7 +99,6 @@ filters:
   - 'do_region.slug == "fra1"'
 """
 
-import re
 import json
 from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.inventory.group import to_safe_group_name
@@ -159,7 +149,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     def _get_payload(self):
         # request parameters
-        api_token = self._template_option("api_token")
+        api_token = self._template_option("oauth_token")
         headers = {
             "Content-Type": "application/json",
             "Authorization": "Bearer {0}".format(api_token),

--- a/poetry.lock
+++ b/poetry.lock
@@ -1535,6 +1535,23 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.11.1"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-mock-3.11.1.tar.gz", hash = "sha256:7f6b125602ac6d743e523ae0bfa71e1a697a2f5534064528c6ff84c2f7c2fc7f"},
+    {file = "pytest_mock-3.11.1-py3-none-any.whl", hash = "sha256:21c279fff83d70763b05f8874cc9cfb3fcacd6d354247a976f9529d19f9acf39"},
+]
+
+[package.dependencies]
+pytest = ">=5.0"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -2463,4 +2480,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.9"
-content-hash = "876bdfe5e28d7f3c709cc32c7c9e6a1885c067ef4c18869d926583e790d9a953"
+content-hash = "bbb46d596c4e47afb1340b70977acb6287882c53d956fa3412ce846170c18842"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ pylint = "^2.17.4"
 pytest = "^7.3.1"
 antsibull-changelog = "^0.22.0"
 antsibull-docs = "^2.3.1"
+pytest-mock = "^3.11.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/unit/plugins/inventory/test_digitalocean.py
+++ b/tests/unit/plugins/inventory/test_digitalocean.py
@@ -208,7 +208,7 @@ def test_populate_groups_sanitization(inventory, mocker, transform):
 def get_option_with_templated_api_token(option):
     options = {
         # "random_choice" with just a single input always returns the same result.
-        "api_token": '{{ lookup("random_choice", "my-do-token") }}',
+        "oauth_token": '{{ lookup("random_choice", "my-do-token") }}',
         "pagination": 100,
     }
     return options.get(option)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #300; drop `api_token` in favor of `oauth_token`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- `digitalocean` inventory plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
N/A
```
