### PR TITLE
Add tests back on main

### DIFF
--- a/.github/workflows/ansible-test-sanity.yml
+++ b/.github/workflows/ansible-test-sanity.yml
@@ -1,6 +1,8 @@
 name: sanity
 
 on:
+  push:
+    branches: [main]
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:

--- a/.github/workflows/ansible-test-unit.yml
+++ b/.github/workflows/ansible-test-unit.yml
@@ -1,5 +1,7 @@
 name: unit
 on:
+  push:
+    branches: [main]
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -2,6 +2,8 @@
 name: black
 
 on:
+  push:
+    branches: [main]
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:

--- a/changelogs/fragments/311-update-tests.yaml
+++ b/changelogs/fragments/311-update-tests.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - tests - add C(sanity), C(units), and C(psf/black) back on merge into C(main) (https://github.com/ansible-collections/community.digitalocean/pull/311).


### PR DESCRIPTION
Accidentally took these tests off of `main` in the last pull request.