### PR TITLE
Release 1.24.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,25 @@ Community DigitalOcean Release Notes
 .. contents:: Topics
 
 
+v1.24.0
+=======
+
+Minor Changes
+-------------
+
+- documentation - use C(true) and C(false) for boolean values in documentation and examples (https://github.com/ansible-collections/community.digitalocean/issues/303).
+- inventory plugin - drop C(api_token) in favor of C(oauth_token) for consistency (https://github.com/ansible-collections/community.digitalocean/issues/300).
+- tests - add C(sanity), C(units), and C(psf/black) back on merge into C(main) (https://github.com/ansible-collections/community.digitalocean/pull/311).
+- tests - drop Ansible 2.9 and Ansible Core 2.10 and 2.11 (https://github.com/ansible-collections/community.digitalocean/pull/310).
+- tests - remove the daily runs (https://github.com/ansible-collections/community.digitalocean/pull/310).
+- tests - run C(psf/black) across all files (https://github.com/ansible-collections/community.digitalocean/pull/310).
+- tests - test against Ansible Core 2.12, 2.13, and 2.14 (https://github.com/ansible-collections/community.digitalocean/pull/310).
+
+Bugfixes
+--------
+
+- digital_ocean_domain - fix ``all_domains`` by using ``get_paginated_data`` to retrieve all of the domains in the account from the paginated domains api endpoint (https://github.com/ansible-collections/community.digitalocean/pull/307).
+
 v1.23.0
 =======
 
@@ -19,8 +38,8 @@ Minor Changes
 Bugfixes
 --------
 
-- inventory plugin - bugfix for baseurl parameter (https://github.com/ansible-collections/community.digitalocean/pull/297).
 - integration tests - add missing `environment` directive on pull request integration testing (https://github.com/ansible-collections/community.digitalocean/issues/293).
+- inventory plugin - bugfix for baseurl parameter (https://github.com/ansible-collections/community.digitalocean/pull/297).
 
 v1.22.0
 =======

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -339,9 +339,9 @@ releases:
   1.23.0:
     changes:
       bugfixes:
-      - inventory plugin - bugfix for baseurl parameter (https://github.com/ansible-collections/community.digitalocean/pull/297).
       - integration tests - add missing `environment` directive on pull request integration
         testing (https://github.com/ansible-collections/community.digitalocean/issues/293).
+      - inventory plugin - bugfix for baseurl parameter (https://github.com/ansible-collections/community.digitalocean/pull/297).
       minor_changes:
       - digital_ocean_load_balancer - add support for C(size_unit) over deprecated
         C(size); deprecate C(algorithm) completely (https://github.com/ansible-collections/community.digitalocean/issues/270).
@@ -358,6 +358,31 @@ releases:
     - 291-pr-integration-tests-branch.yaml
     - 293-integration-test-pr-environment.yaml
     release_date: '2022-12-29'
+  1.24.0:
+    changes:
+      bugfixes:
+      - digital_ocean_domain - fix ``all_domains`` by using ``get_paginated_data``
+        to retrieve all of the domains in the account from the paginated domains api
+        endpoint (https://github.com/ansible-collections/community.digitalocean/pull/307).
+      minor_changes:
+      - documentation - use C(true) and C(false) for boolean values in documentation
+        and examples (https://github.com/ansible-collections/community.digitalocean/issues/303).
+      - inventory plugin - drop C(api_token) in favor of C(oauth_token) for consistency
+        (https://github.com/ansible-collections/community.digitalocean/issues/300).
+      - tests - add C(sanity), C(units), and C(psf/black) back on merge into C(main)
+        (https://github.com/ansible-collections/community.digitalocean/pull/311).
+      - tests - drop Ansible 2.9 and Ansible Core 2.10 and 2.11 (https://github.com/ansible-collections/community.digitalocean/pull/310).
+      - tests - remove the daily runs (https://github.com/ansible-collections/community.digitalocean/pull/310).
+      - tests - run C(psf/black) across all files (https://github.com/ansible-collections/community.digitalocean/pull/310).
+      - tests - test against Ansible Core 2.12, 2.13, and 2.14 (https://github.com/ansible-collections/community.digitalocean/pull/310).
+    fragments:
+    - 300-inventory-plugin-oauth-token.yaml
+    - 303-documentation-bool-true-false.yaml
+    - 307-get-all-domains-pagination-fix.yaml
+    - 310-update-tests.yaml
+    - 311-update-tests.yaml
+    - 312-double-integration-test-timeout.yaml
+    release_date: '2023-08-12'
   1.3.0:
     modules:
     - description: Create and delete a DigitalOcean database

--- a/changelogs/fragments/300-inventory-plugin-oauth-token.yaml
+++ b/changelogs/fragments/300-inventory-plugin-oauth-token.yaml
@@ -1,2 +1,0 @@
-minor_changes:
-  - inventory plugin - drop C(api_token) in favor of C(oauth_token) for consistency (https://github.com/ansible-collections/community.digitalocean/issues/300).

--- a/changelogs/fragments/303-documentation-bool-true-false.yaml
+++ b/changelogs/fragments/303-documentation-bool-true-false.yaml
@@ -1,2 +1,0 @@
-minor_changes:
-  - documentation - use C(true) and C(false) for boolean values in documentation and examples (https://github.com/ansible-collections/community.digitalocean/issues/303).

--- a/changelogs/fragments/307-get-all-domains-pagination-fix.yaml
+++ b/changelogs/fragments/307-get-all-domains-pagination-fix.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - digital_ocean_domain - fix ``all_domains`` by using ``get_paginated_data`` to retrieve all of the domains in the account from the paginated domains api endpoint (https://github.com/ansible-collections/community.digitalocean/pull/307).

--- a/changelogs/fragments/310-update-tests.yaml
+++ b/changelogs/fragments/310-update-tests.yaml
@@ -1,8 +1,0 @@
-minor_changes:
-  - tests - run C(psf/black) across all files (https://github.com/ansible-collections/community.digitalocean/pull/310).
-  - tests - remove the daily runs (https://github.com/ansible-collections/community.digitalocean/pull/310).
-  - tests - drop Ansible 2.9 and Ansible Core 2.10 and 2.11 (https://github.com/ansible-collections/community.digitalocean/pull/310).
-  - tests - test against Ansible Core 2.12, 2.13, and 2.14 (https://github.com/ansible-collections/community.digitalocean/pull/310).
-trivial:
-  - documentation - add C(CODEOWNERS) (https://github.com/ansible-collections/community.digitalocean/pull/310).
-  - python - add C(pyproject.toml) and C(poetry.lock) (https://github.com/ansible-collections/community.digitalocean/pull/310).

--- a/changelogs/fragments/311-update-tests.yaml
+++ b/changelogs/fragments/311-update-tests.yaml
@@ -1,2 +1,0 @@
-minor_changes:
-  - tests - add C(sanity), C(units), and C(psf/black) back on merge into C(main) (https://github.com/ansible-collections/community.digitalocean/pull/311).

--- a/changelogs/fragments/312-double-integration-test-timeout.yaml
+++ b/changelogs/fragments/312-double-integration-test-timeout.yaml
@@ -1,2 +1,0 @@
-trivial:
-  - tests - double the integration timeout (https://github.com/ansible-collections/community.digitalocean/pull/312).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -43,7 +43,7 @@ tags:
   - digitalocean
   - cloud
   - droplet
-version: 1.23.0
+version: 1.24.0
 build_ignore:
   - .DS_Store
   - '*.tar.gz'


### PR DESCRIPTION
Minor Changes
-------------

- documentation - use C(true) and C(false) for boolean values in documentation and examples (https://github.com/ansible-collections/community.digitalocean/issues/303).
- inventory plugin - drop C(api_token) in favor of C(oauth_token) for consistency (https://github.com/ansible-collections/community.digitalocean/issues/300).
- tests - add C(sanity), C(units), and C(psf/black) back on merge into C(main) (https://github.com/ansible-collections/community.digitalocean/pull/311).
- tests - drop Ansible 2.9 and Ansible Core 2.10 and 2.11 (https://github.com/ansible-collections/community.digitalocean/pull/310).
- tests - remove the daily runs (https://github.com/ansible-collections/community.digitalocean/pull/310).
- tests - run C(psf/black) across all files (https://github.com/ansible-collections/community.digitalocean/pull/310).
- tests - test against Ansible Core 2.12, 2.13, and 2.14 (https://github.com/ansible-collections/community.digitalocean/pull/310).

Bugfixes
--------

- digital_ocean_domain - fix ``all_domains`` by using ``get_paginated_data`` to retrieve all of the domains in the account from the paginated domains api endpoint (https://github.com/ansible-collections/community.digitalocean/pull/307).
