### PR TITLE
add CNAME example to domain_record module

### DIFF
--- a/changelogs/fragments/314-add-cname-example-to-domain_record-module.yaml
+++ b/changelogs/fragments/314-add-cname-example-to-domain_record-module.yaml
@@ -1,2 +1,2 @@
 trivial
-  - docs - add cname example to domain_record module.yaml (https://github.com/ansible-collections/community.digitalocean/pull/314)
+  - docs - add cname example to domain_record module.yaml (https://github.com/ansible-collections/community.digitalocean/pull/314).

--- a/changelogs/fragments/314-add-cname-example-to-domain_record-module.yaml
+++ b/changelogs/fragments/314-add-cname-example-to-domain_record-module.yaml
@@ -1,0 +1,2 @@
+trivial
+  - docs - add cname example to domain_record module.yaml (https://github.com/ansible-collections/community.digitalocean/pull/314)

--- a/changelogs/fragments/314-add-cname-example-to-domain_record-module.yaml
+++ b/changelogs/fragments/314-add-cname-example-to-domain_record-module.yaml
@@ -1,2 +1,2 @@
-trivial
+trivial:
   - docs - add cname example to domain_record module.yaml (https://github.com/ansible-collections/community.digitalocean/pull/314).

--- a/plugins/modules/digital_ocean_domain_record.py
+++ b/plugins/modules/digital_ocean_domain_record.py
@@ -145,6 +145,19 @@ EXAMPLES = """
     domain: example.com
     record_id: 1234567
 
+- name: Create CNAME records for www, git and status subdomains
+  community.digitalocean.digital_ocean_domain_record:
+    state: present
+    oauth_token: "{{ lookup('ansible.builtin.env', 'DO_API_TOKEN') }}"
+    domain: example.com
+    type: CNAME
+    name: "{{ item }}"
+    data: example.com
+  with_items:
+    - www
+    - git
+    - status
+
 - name: Create MX record with priority 10 for example.com
   community.digitalocean.digital_ocean_domain_record:
     state: present


### PR DESCRIPTION
##### SUMMARY

Here I added an example for the CNAME type of the domain_record module.
I believe subdomains to be a particularly common usage of this record type.
I added the subdomains I use.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME

digital_ocean_domain_record.py

##### ADDITIONAL INFORMATION

When setting up my cname records it wasn't apparent what to put into the data, domain, or name fields, leading to a cryptic error on CNAMEs not being allowed to refer to themselves.