### PR TITLE
Inventory plugin: restore reading auth token from env variables

### DIFF
--- a/changelogs/fragments/316-inventory-plugin-restore-reading-auth-token-from-env-variables.yaml
+++ b/changelogs/fragments/316-inventory-plugin-restore-reading-auth-token-from-env-variables.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - inventory plugin - restore reading auth token from env variables (https://github.com/ansible-collections/community.digitalocean/pull/315).

--- a/plugins/doc_fragments/digital_ocean.py
+++ b/plugins/doc_fragments/digital_ocean.py
@@ -22,9 +22,13 @@ options:
     description:
       - DigitalOcean OAuth token.
       - "There are several other environment variables which can be used to provide this value."
-      - "i.e., - 'DO_API_TOKEN', 'DO_API_KEY', 'DO_OAUTH_TOKEN' and 'OAUTH_TOKEN'"
     type: str
     aliases: [ api_token ]
+    env:
+      - name: DO_API_TOKEN
+      - name: DO_API_KEY
+      - name: DO_OAUTH_TOKEN
+      - name: OAUTH_TOKEN
   timeout:
     description:
     - The timeout in seconds used for polling DigitalOcean's API.


### PR DESCRIPTION


##### SUMMARY
By completely removing any documentation for api_token / oauth_token, commit 609df3eaf506a5db13a960d5fc4bf4f70b5a3e50 suddenly broke support for reading the auth token from environment variables (which magically happens to work based on plugin options documentation).

Restore the documentation bits by matching docs fragment. While at it, also match the documented list of supported env variables which can be used as auth token sources.

Fixes #315

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Inventory plugin
