### PR TITLE
Release v1.26.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,20 @@ Community DigitalOcean Release Notes
 .. contents:: Topics
 
 
+v1.26.0
+=======
+
+Minor Changes
+-------------
+
+- digital_ocean_kubernetes - add project_name parameter (https://github.com/ansible-collections/community.digitalocean/issues/264).
+
+Bugfixes
+--------
+
+- The C(project_name) parameter for many modules was used by alias C(project) internally in the codebase, but to work properly C(project_name) must be used in the code. Replace self.module.params.get("project") with self.module.params.get("project_name") (https://github.com/ansible-collections/community.digitalocean/issues/326).
+- digital_ocean_kubernetes - module didn't return kubeconfig properly, return documentation was invalid. Fixed version returns data with the same structure all the time, also it is aligned with M(community.digitalocean.digital_ocean_kubernetes_info) documentation return data now. (https://github.com/ansible-collections/community.digitalocean/issues/322).
+
 v1.25.0
 =======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -398,6 +398,29 @@ releases:
       name: digital_ocean_project_resource_info
       namespace: ''
     release_date: '2023-12-11'
+  1.26.0:
+    changes:
+      bugfixes:
+      - The C(project_name) parameter for many modules was used by alias C(project)
+        internally in the codebase, but to work properly C(project_name) must be used
+        in the code. Replace self.module.params.get("project") with self.module.params.get("project_name")
+        (https://github.com/ansible-collections/community.digitalocean/issues/326).
+      - digital_ocean_kubernetes - module didn't return kubeconfig properly, return
+        documentation was invalid. Fixed version returns data with the same structure
+        all the time, also it is aligned with M(community.digitalocean.digital_ocean_kubernetes_info)
+        documentation return data now. (https://github.com/ansible-collections/community.digitalocean/issues/322).
+      minor_changes:
+      - digital_ocean_kubernetes - add project_name parameter (https://github.com/ansible-collections/community.digitalocean/issues/264).
+    fragments:
+    - 264-kubernetes-project.yaml
+    - 322-k8s-module-kubeconfig.yaml
+    - 326-project-name-param.yaml
+    - 334-droplet-ci-images.yml
+    - 337-refactor-integration-tests.yml
+    - 338-refactor-integration-tests.yml
+    - 339-refactor-integration-tests.yml
+    - 340-fix-refactor-integration-tests.yml
+    release_date: '2024-01-01'
   1.3.0:
     modules:
     - description: Create and delete a DigitalOcean database

--- a/changelogs/fragments/264-kubernetes-project.yaml
+++ b/changelogs/fragments/264-kubernetes-project.yaml
@@ -1,3 +1,0 @@
-minor_changes:
-  - digital_ocean_kubernetes - add project_name parameter
-    (https://github.com/ansible-collections/community.digitalocean/issues/264).

--- a/changelogs/fragments/322-k8s-module-kubeconfig.yaml
+++ b/changelogs/fragments/322-k8s-module-kubeconfig.yaml
@@ -1,5 +1,0 @@
-bugfixes:
-  - digital_ocean_kubernetes - module didn't return kubeconfig properly, return documentation was 
-    invalid. Fixed version returns data with the same structure all the time, also it is aligned 
-    with M(community.digitalocean.digital_ocean_kubernetes_info) documentation return data now.
-    (https://github.com/ansible-collections/community.digitalocean/issues/322).

--- a/changelogs/fragments/326-project-name-param.yaml
+++ b/changelogs/fragments/326-project-name-param.yaml
@@ -1,5 +1,0 @@
-bugfixes:
-  - The C(project_name) parameter for many modules was used by alias C(project) internally in the 
-    codebase, but to work properly C(project_name) must be used in the code. Replace 
-    self.module.params.get("project") with self.module.params.get("project_name")  
-    (https://github.com/ansible-collections/community.digitalocean/issues/326).

--- a/changelogs/fragments/334-droplet-ci-images.yml
+++ b/changelogs/fragments/334-droplet-ci-images.yml
@@ -1,2 +1,0 @@
-trivial:
-  - ci - switch Droplet CI images to Jammy (https://github.com/ansible-collections/community.digitalocean/issues/334).

--- a/changelogs/fragments/337-refactor-integration-tests.yml
+++ b/changelogs/fragments/337-refactor-integration-tests.yml
@@ -1,2 +1,0 @@
-trivial:
-  - ci - refactor integration test workflows (https://github.com/ansible-collections/community.digitalocean/pull/337).

--- a/changelogs/fragments/338-refactor-integration-tests.yml
+++ b/changelogs/fragments/338-refactor-integration-tests.yml
@@ -1,2 +1,0 @@
-trivial:
-  - ci - refactor integration test workflows (https://github.com/ansible-collections/community.digitalocean/pull/338).

--- a/changelogs/fragments/339-refactor-integration-tests.yml
+++ b/changelogs/fragments/339-refactor-integration-tests.yml
@@ -1,2 +1,0 @@
-trivial:
-  - ci - refactor pull request integration test workflow (https://github.com/ansible-collections/community.digitalocean/pull/339).

--- a/changelogs/fragments/340-fix-refactor-integration-tests.yml
+++ b/changelogs/fragments/340-fix-refactor-integration-tests.yml
@@ -1,2 +1,0 @@
-trivial:
-  - ci - refactor pull request integration test workflow (https://github.com/ansible-collections/community.digitalocean/pull/340).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -44,7 +44,7 @@ tags:
   - digitalocean
   - cloud
   - droplet
-version: 1.25.0
+version: 1.26.0
 build_ignore:
   - .DS_Store
   - '*.tar.gz'


### PR DESCRIPTION
Minor Changes
-------------

- digital_ocean_kubernetes - add project_name parameter (https://github.com/ansible-collections/community.digitalocean/issues/264).

Bugfixes
--------

- The C(project_name) parameter for many modules was used by alias C(project) internally in the codebase, but to work properly C(project_name) must be used in the code. Replace self.module.params.get("project") with self.module.params.get("project_name") (https://github.com/ansible-collections/community.digitalocean/issues/326).
- digital_ocean_kubernetes - module didn't return kubeconfig properly, return documentation was invalid. Fixed version returns data with the same structure all the time, also it is aligned with M(community.digitalocean.digital_ocean_kubernetes_info) documentation return data now. (https://github.com/ansible-collections/community.digitalocean/issues/322).
