### PR TITLE
Add new and drop deprecated versions of `ansible-core`

### DIFF
--- a/.github/workflows/ansible-test-sanity.yml
+++ b/.github/workflows/ansible-test-sanity.yml
@@ -10,20 +10,25 @@ on:
 jobs:
   sanity:
     timeout-minutes: 30
-    name: Sanity (Ⓐ$${{ matrix.ansible }})
+    name: Sanity (Ⓐ$${{ matrix.versions.ansible }})
     strategy:
       fail-fast: false
       matrix:
-        ansible:
-          - stable-2.12
-          - stable-2.13
-          - stable-2.14
+        versions:
+          - ansible: stable-2.14
+            python: "3.9"
+          - ansible: stable-2.15
+            python: "3.9"
+          - ansible: stable-2.16
+            python: "3.10"
+          - ansible: devel
+            python: "3.10"
     runs-on: ubuntu-22.04
     steps:
       - name: Perform testing
         uses: ansible-community/ansible-test-gh-action@release/v1
         with:
-          ansible-core-version: ${{ matrix.ansible }}
-          origin-python-version: 3.9
-          target-python-version: 3.9
+          ansible-core-version: ${{ matrix.versions.ansible }}
+          origin-python-version: ${{ matrix.versions.python }}
+          target-python-version: ${{ matrix.versions.python }}
           testing-type: sanity

--- a/.github/workflows/ansible-test-unit.yml
+++ b/.github/workflows/ansible-test-unit.yml
@@ -10,21 +10,26 @@ jobs:
   units:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
-    name: Units (Ⓐ${{ matrix.ansible }})
+    name: Units (Ⓐ${{ matrix.versions.ansible }})
     strategy:
       fail-fast: false
       matrix:
-        ansible:
-          - stable-2.12
-          - stable-2.13
-          - stable-2.14
+        versions:
+          - ansible: stable-2.14
+            python: "3.9"
+          - ansible: stable-2.15
+            python: "3.9"
+          - ansible: stable-2.16
+            python: "3.10"
+          - ansible: devel
+            python: "3.10"
     steps:
       - name: Perform testing
         uses: ansible-community/ansible-test-gh-action@release/v1
         with:
-          ansible-core-version: ${{ matrix.ansible }}
-          origin-python-version: 3.9
-          target-python-version: 3.9
+          ansible-core-version: ${{ matrix.versions.ansible }}
+          origin-python-version: ${{ matrix.versions.python }}
+          target-python-version: ${{ matrix.versions.python }}
           testing-type: units
           test-deps: >-
             ansible.netcommon

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This collection contains modules and plugins to assist in automating [DigitalOce
 
 The collection is tested and supported with:
 
-- ansible-core >= 2.12 (not including `devel`)
+- ansible-core >= 2.14 (including `devel`)
 - python >= 3.9
 
 ### Installing the Collection from Ansible Galaxy

--- a/changelogs/fragments/351-ansible-core-versions.yml
+++ b/changelogs/fragments/351-ansible-core-versions.yml
@@ -1,0 +1,2 @@
+trivial:
+  - ci - add new and drop deprecated versions of ``ansible-core`` (https://github.com/ansible-collections/community.digitalocean/issues/351).

--- a/tests/utils/render.sh
+++ b/tests/utils/render.sh
@@ -8,7 +8,9 @@ set -u
 
 function main()
 {
+  # shellcheck disable=SC2155
   readonly template="$1"; shift
+  # shellcheck disable=SC2155
   readonly content="$(cat "$template")"
 
   eval "echo \"$content\""


### PR DESCRIPTION
Fixes #351; drop deprecated versions of `ansible-core` (2.12 and 2.13), add newer versions (2.14 and 2.15).