### PR TITLE
Moved http status check up to catch more cases

### DIFF
--- a/plugins/modules/digital_ocean_droplet.py
+++ b/plugins/modules/digital_ocean_droplet.py
@@ -621,6 +621,17 @@ class DODroplet(object):
         json_data = response.json
         status_code = response.status_code
         message = json_data.get("message", "no error message")
+
+        # action and other fields may not be available in case of error, check first
+        # will catch Not Authorized due to restrictive Scopes
+        if status_code >= 400:
+            self.module.fail_json(
+                changed=False,
+                msg=DODroplet.failure_message["failed_to"].format(
+                    "post", "action", status_code, message
+                ),
+            )
+
         action = json_data.get("action", None)
         action_id = action.get("id", None)
         action_status = action.get("status", None)
@@ -630,14 +641,6 @@ class DODroplet(object):
                 changed=False,
                 msg=DODroplet.failure_message["unexpected"].format(
                     "no action, ID, or status"
-                ),
-            )
-
-        if status_code >= 400:
-            self.module.fail_json(
-                changed=False,
-                msg=DODroplet.failure_message["failed_to"].format(
-                    "post", "action", status_code, message
                 ),
             )
 


### PR DESCRIPTION
##### SUMMARY
When using reduced Scopes, some API calls may fail with a 403 if you didn't provide enough scopes for all of the actions being performed. This caused a crash due to some fields not existing in the response, and them being referenced before the check for the http code. I just moved the check a little bit up in the code.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
digital_ocean_droplet

##### ADDITIONAL INFORMATION
To reproduce the error, just create a new API Key without any droplet Scopes and try to create a new droplet. Other cases relate to specific options used in the create and the scopes that the key has.
