### PR TITLE
[FIX] digitalocean inventory plugin: missing closing parenthesis in examples section

### DIFF
--- a/plugins/inventory/digitalocean.py
+++ b/plugins/inventory/digitalocean.py
@@ -69,7 +69,7 @@ options:
 EXAMPLES = r"""
 # Using keyed groups and compose for hostvars
 plugin: community.digitalocean.digitalocean
-oauth_token: '{{ lookup("pipe", "./get-do-token.sh" }}'
+oauth_token: '{{ lookup("pipe", "./get-do-token.sh") }}'
 attributes:
   - id
   - name


### PR DESCRIPTION
##### SUMMARY

There is a typo in the documentation examples section.
The closing parenthesis of the pipe lookup is missing, so the provided code snippet is unusable.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

digitalocean inventory plugin
