### PR TITLE
Support kubernetes_ids for source and destination rules in ``digital_ocean_firewall``

### DIFF
--- a/changelogs/fragments/309-kubernetes-ids-firewall.yml
+++ b/changelogs/fragments/309-kubernetes-ids-firewall.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - digital_ocean_firewall - add support for kubernetes_ids to inbound and outbound rules
+    (https://github.com/ansible-collections/community.digitalocean/issues/309).

--- a/plugins/modules/digital_ocean_firewall.py
+++ b/plugins/modules/digital_ocean_firewall.py
@@ -87,6 +87,12 @@ options:
             description:
               - List of strings containing the IDs of the Load Balancers to which the firewall will allow traffic
             required: false
+          kubernetes_ids:
+            type: list
+            elements: str
+            description:
+              - List of strings containing the IDs of the Kubernetes clusters to which the firewall will allow traffic
+            required: false
           tags:
             type: list
             elements: str
@@ -138,6 +144,12 @@ options:
             description:
               - List of strings containing the IDs of the Load Balancers to which the firewall will allow traffic
             required: false
+          kubernetes_ids:
+            type: list
+            elements: str
+            description:
+              - List of strings containing the IDs of the Kubernetes clusters to which the firewall will allow traffic
+            required: false
           tags:
             type: list
             elements: str
@@ -165,6 +177,7 @@ EXAMPLES = """
           addresses: ["1.2.3.4"]
           droplet_ids: ["my_droplet_id_1", "my_droplet_id_2"]
           load_balancer_uids: ["my_lb_id_1", "my_lb_id_2"]
+          kubernetes_ids: ["my_k8s_id_1", "my_k8s_id_2"]
           tags: ["tag_1", "tag_2"]
       - protocol: "tcp"
         ports: "80"
@@ -215,6 +228,10 @@ data:
                   "load_balancer_uids": [
                       "my_lb_id_1",
                       "my_lb_id_2"
+                  ],
+                  "kubernetes_ids": [
+                      "my_k8s_id_1",
+                      "my_k8s_id_2"
                   ],
                   "tags": [
                       "tag_1",
@@ -293,6 +310,7 @@ address_spec = dict(
     addresses=dict(type="list", elements="str", required=False),
     droplet_ids=dict(type="list", elements="str", required=False),
     load_balancer_uids=dict(type="list", elements="str", required=False),
+    kubernetes_ids=dict(type="list", elements="str", required=False),
     tags=dict(type="list", elements="str", required=False),
 )
 
@@ -384,12 +402,16 @@ class DOFirewall(object):
         load_balancer_uids = obj.get("load_balancer_uids") or []
         load_balancer_uids = [str(uid) for uid in load_balancer_uids]
 
+        kubernetes_ids = obj.get("kubernetes_ids") or []
+        kubernetes_ids = [str(k8s_id) for k8s_id in kubernetes_ids]
+
         tags = obj.get("tags") or []
 
         data = {
             "addresses": addresses,
             "droplet_ids": droplet_ids,
             "load_balancer_uids": load_balancer_uids,
+            "kubernetes_ids": kubernetes_ids,
             "tags": tags,
         }
 


### PR DESCRIPTION
##### SUMMARY
Fixes #309

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
``digital_ocean_firewall``

##### ADDITIONAL INFORMATION
[Digital Ocean API ref](https://docs.digitalocean.com/reference/api/api-reference/#operation/firewalls_create)
